### PR TITLE
Add CI npm script, avoid double linting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ commands:
       - setup-nodejs
       - run:
           name: Test
-          command: yarn test
+          command: yarn ci
   run-lint:
     steps:
       - prepare-env

--- a/package.json
+++ b/package.json
@@ -5,8 +5,10 @@
   "scripts": {
     "start": "rm -rf ./node_modules/.cache/babel-loader && node scripts/start.js",
     "build": "node scripts/build.js",
-    "test": "npm run test:lint && node scripts/test.js",
-    "test:lint": "standard"
+    "test": "npm run test:lint && npm run test:unit",
+    "test:lint": "standard",
+    "test:unit": "node scripts/test.js",
+    "ci": "CI=1 npm run test:unit"
   },
   "dependencies": {
     "@holochain/hc-web-client": "^0.5.0",


### PR DESCRIPTION
Let's use `npm run ci` as a contract between `package.json` and CircleCI.
Linting task remains as was - `npm run test:lint`