### PR TITLE
Remove mock data reset

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,8 +145,7 @@
     ],
     "setupFilesAfterEnv": [
       "@testing-library/react/cleanup-after-each",
-      "@testing-library/jest-dom/extend-expect",
-      "<rootDir>/src/mock-dnas/resetMockDataAfterEach"
+      "@testing-library/jest-dom/extend-expect"
     ],
     "testMatch": [
       "<rootDir>/src/**/__tests__/**/*.{js,jsx,ts,tsx}",

--- a/src/graphql-server/resolvers.js
+++ b/src/graphql-server/resolvers.js
@@ -3,13 +3,27 @@ import HyloDnaInterface from './dnaInterfaces/hyloDnaInterface'
 import HappStoreDnaInterface, { getHappDetails } from './dnaInterfaces/happStoreDnaInterface'
 import HhaDnaInterface from './dnaInterfaces/hhaDnaInterface'
 import EnvoyInterface from './dnaInterfaces/envoyInterface'
-
 import {
   dataMappedCall,
   toUiData
 } from './dataMapping'
+// TODO: dataMapping should probably be happening in the dnainterfaces
 
 export const resolvers = {
+  Query: {
+    me: async () => toUiData('person', await HyloDnaInterface.currentUser.get()),
+
+    happStoreUser: () => HappStoreDnaInterface.currentUser.get(),
+
+    hostingUser: () => HhaDnaInterface.currentUser.get(),
+
+    allHapps: () => HappStoreDnaInterface.happs.all(),
+
+    allAvailableHapps: () => Promise.map(HhaDnaInterface.happs.allAvailable(), getHappDetails),
+
+    allHostedHapps: () => Promise.map(HhaDnaInterface.happs.allHosted(), getHappDetails)
+  },
+
   Mutation: {
     registerUser: (_, userData) => dataMappedCall('person', userData, HyloDnaInterface.currentUser.create),
 
@@ -35,20 +49,6 @@ export const resolvers = {
       }
       return getHappDetails(happ)
     }
-  },
-
-  Query: {
-    me: async () => toUiData('person', await HyloDnaInterface.currentUser.get()),
-
-    happStoreUser: () => HappStoreDnaInterface.currentUser.get(),
-
-    hostingUser: () => HhaDnaInterface.currentUser.get(),
-
-    allHapps: () => HappStoreDnaInterface.happs.all(),
-
-    allAvailableHapps: () => Promise.map(HhaDnaInterface.happs.allAvailable(), getHappDetails),
-
-    allHostedHapps: () => Promise.map(HhaDnaInterface.happs.allHosted(), getHappDetails)
   }
 }
 

--- a/src/mock-dnas/mockData.js
+++ b/src/mock-dnas/mockData.js
@@ -1,11 +1,10 @@
-import { cloneDeep } from 'lodash/fp'
 import happStore from './happStore'
 import hha from './hha'
 
 // data is a tree organized by instanceId > zome > function
 // leaves can either be an object, or a function which is called with the zome call args, so can update other parts of the tree.
 
-const defaultData = {
+const data = {
   hylo: {
     people: {
       get_me: {
@@ -25,12 +24,6 @@ const defaultData = {
   },
   'happ-store': happStore,
   hha
-}
-
-let data = cloneDeep(defaultData)
-
-export function resetMockData () {
-  data = cloneDeep(defaultData)
 }
 
 export default data

--- a/src/mock-dnas/resetMockDataAfterEach.js
+++ b/src/mock-dnas/resetMockDataAfterEach.js
@@ -1,2 +1,0 @@
-import { resetMockData } from './mockData.js'
-afterEach(resetMockData)


### PR DESCRIPTION
@JettTech @danekszy @lorenjohnson 
Tagging you in this just so you get a chance to see it, I'd be surprised if this change breaks anything you're doing, but if it does, please let me know.

I'm removing the code I added that resets the mock data after each test. It was causing a problem in using the mock data as originally intended: for manually testing the UI. The problem was soluble, but it started to feel increasingly like a bad smell. So for now, we will not be able to use the mock data to test mutations, which means leaning more on the unit testing pattern rather than the integration testing pattern.

LMK if you have thoughts or questions about this