### PR TITLE
Run test:unit instead of test in the test step of circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ commands:
       - setup-nodejs
       - run:
           name: Test
-          command: npm run test:unit
+          command: npm run ci
   run-lint:
     steps:
       - prepare-env

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ commands:
       - setup-nodejs
       - run:
           name: Test
-          command: npm test
+          command: npm run test:unit
   run-lint:
     steps:
       - prepare-env


### PR DESCRIPTION
The current setup means that bad linting causes *both* steps to fail. So the test step fails even if all the tests are fine.

Does this fix look right to you @danekszy?