### PR TITLE
4705 holofuel data layer updated

### DIFF
--- a/src/data-interfaces/HoloFuelDnaInterface.js
+++ b/src/data-interfaces/HoloFuelDnaInterface.js
@@ -1,4 +1,5 @@
 import _ from 'lodash'
+import { mapValues} from 'lodash/fp'
 import { instanceCreateZomeCall } from '../holochainClient'
 
 export const currentDataTimeIso = () => new Date().toISOString()
@@ -90,12 +91,8 @@ function presentTransaction (transaction) {
   const stateStage = state.split('/')[1]
   const stateDirection = state.split('/')[0] // NOTE: This returns either 'incoming' or 'outgoing,' wherein, 'incoming' indicates the recipient of funds, 'outgoing' indicates the spender of funds.
   // NOTE: *Holofuel does NOT yet provide a balance that represents the 'RESULTING ACCT BALANCE after this transaction adjustment', instead of the only the tx adjustment balance or real-time balance.*
-  const adjustmentValues = Object.values(adjustment).map(key => key.Ok)
-  const adjustmentKeys = Object.keys(adjustment)
-  const parsedAdjustment = adjustmentValues.reduce((result, field, index) => {
-    result[adjustmentKeys[index]] = field
-    return result
-  }, {})
+  const parsedAdjustment = mapValues('Ok', adjustment)
+
   switch (stateStage) {
     case 'completed': {
       if (event.Receipt) return presentReceipt({ origin, event, stateDirection, eventTimestamp: timestamp.event, fees: parsedAdjustment.fees, presentBalance: parsedAdjustment.resulting_balance })

--- a/src/data-interfaces/HoloFuelDnaInterface.js
+++ b/src/data-interfaces/HoloFuelDnaInterface.js
@@ -43,7 +43,8 @@ const presentReceipt = ({ origin, event, stateDirection, eventTimestamp, fees, p
     type: event.Receipt.cheque.invoice.promise.request ? 'request' : 'offer', // this inicates the original event type (eg. 'I requested hf from you', 'You sent a offer to me', etc.)
     timestamp: eventTimestamp,
     fees,
-    presentBalance
+    presentBalance,
+    notes: event.Receipt.cheque.invoice.promise.tx.notes
   }
 }
 
@@ -59,7 +60,8 @@ const presentCheque = ({ origin, event, stateDirection, eventTimestamp, fees, pr
     type: event.Cheque.invoice.promise.request ? 'request' : 'offer', // this inicates the original event type (eg. 'I requested hf from you', 'You sent a offer to me', etc.)
     timestamp: eventTimestamp,
     fees,
-    presentBalance
+    presentBalance,
+    notes: event.Receipt.cheque.invoice.promise.tx.notes
   }
 }
 
@@ -87,10 +89,17 @@ function presentTransaction (transaction) {
   const { state, origin, event, timestamp, adjustment } = transaction
   const stateStage = state.split('/')[1]
   const stateDirection = state.split('/')[0] // NOTE: This returns either 'incoming' or 'outgoing,' wherein, 'incoming' indicates the recipient of funds, 'outgoing' indicates the spender of funds.
+  // NOTE: *Holofuel does NOT yet provide a balance that represents the 'RESULTING ACCT BALANCE after this transaction adjustment', instead of the only the tx adjustment balance or real-time balance.*
+  const adjustmentValues = Object.values(adjustment).map(key => key.Ok)
+  const adjustmentKeys = Object.keys(adjustment)
+  const parsedAdjustment = adjustmentValues.reduce((result, field, index) => {
+    result[adjustmentKeys[index]] = field
+    return result
+  }, {})
   switch (stateStage) {
     case 'completed': {
-      if (event.Receipt) return presentReceipt({ origin, event, stateDirection, eventTimestamp: timestamp.event, fees: adjustment.fees, presentBalance: adjustment.balance })
-      if (event.Cheque) return presentCheque({ origin, event, stateDirection, eventTimestamp: timestamp.event, fees: adjustment.fees, presentBalance: adjustment.balance })
+      if (event.Receipt) return presentReceipt({ origin, event, stateDirection, eventTimestamp: timestamp.event, fees: parsedAdjustment.fees, presentBalance: parsedAdjustment.balance })
+      if (event.Cheque) return presentCheque({ origin, event, stateDirection, eventTimestamp: timestamp.event, fees: parsedAdjustment.fees, presentBalance: parsedAdjustment.balance })
       throw new Error('Completed event did not have a Receipt or Cheque event')
     }
     case 'rejected': {
@@ -111,6 +120,15 @@ function presentTransaction (transaction) {
 }
 
 const HoloFuelDnaInterface = {
+  user: {
+    get: async (agentId) => {
+      const { nick, pub_sign_key: id } = await createZomeCall('transactions/whoami')({ agentId })
+      return {
+        id,
+        nickname: nick
+      }
+    }
+  },
   ledger: {
     get: async () => {
       const { balance, credit, payable, receivable, fees } = await createZomeCall('transactions/ledger_state')()
@@ -173,7 +191,7 @@ const HoloFuelDnaInterface = {
 
     // NOTE: Below we reflect our current change to the receive_payment API; the only param should now be the transaction's origin id
     accept: async (transactionId) => {
-      await createZomeCall('transactions/receive_payment')({ origin: transactionId })
+      await createZomeCall('transactions/receive_payments_pending')({ origin: transactionId })
       return {
         id: transactionId,
         amount: 0, // NOTE: This data needs to be pulled from the gql cache

--- a/src/data-interfaces/HoloFuelDnaInterface.js
+++ b/src/data-interfaces/HoloFuelDnaInterface.js
@@ -61,7 +61,7 @@ const presentCheque = ({ origin, event, stateDirection, eventTimestamp, fees, pr
     timestamp: eventTimestamp,
     fees,
     presentBalance,
-    notes: event.Receipt.cheque.invoice.promise.tx.notes
+    notes: event.Cheque.invoice.promise.tx.notes
   }
 }
 
@@ -98,8 +98,8 @@ function presentTransaction (transaction) {
   }, {})
   switch (stateStage) {
     case 'completed': {
-      if (event.Receipt) return presentReceipt({ origin, event, stateDirection, eventTimestamp: timestamp.event, fees: parsedAdjustment.fees, presentBalance: parsedAdjustment.balance })
-      if (event.Cheque) return presentCheque({ origin, event, stateDirection, eventTimestamp: timestamp.event, fees: parsedAdjustment.fees, presentBalance: parsedAdjustment.balance })
+      if (event.Receipt) return presentReceipt({ origin, event, stateDirection, eventTimestamp: timestamp.event, fees: parsedAdjustment.fees, presentBalance: parsedAdjustment.resulting_balance })
+      if (event.Cheque) return presentCheque({ origin, event, stateDirection, eventTimestamp: timestamp.event, fees: parsedAdjustment.fees, presentBalance: parsedAdjustment.resulting_balance })
       throw new Error('Completed event did not have a Receipt or Cheque event')
     }
     case 'rejected': {
@@ -121,11 +121,12 @@ function presentTransaction (transaction) {
 
 const HoloFuelDnaInterface = {
   user: {
-    get: async (agentId) => {
-      const { nick, pub_sign_key: id } = await createZomeCall('transactions/whoami')({ agentId })
+    get: async ({ agentId }) => {
+      const result = await createZomeCall('transactions/whoami')({ agentId })
+      if (result.error) throw new Error('There was an error locating the agent nickname. ERROR: ', result.error)
       return {
-        id,
-        nickname: nick
+        id: result.pub_sign_key,
+        nickname: result.nick
       }
     }
   },

--- a/src/data-interfaces/HoloFuelDnaInterface.js
+++ b/src/data-interfaces/HoloFuelDnaInterface.js
@@ -1,5 +1,5 @@
 import _ from 'lodash'
-import { mapValues} from 'lodash/fp'
+import { mapValues } from 'lodash/fp'
 import { instanceCreateZomeCall } from '../holochainClient'
 
 export const currentDataTimeIso = () => new Date().toISOString()

--- a/src/data-interfaces/__mocks__/HoloFuelInterface.js
+++ b/src/data-interfaces/__mocks__/HoloFuelInterface.js
@@ -1,6 +1,6 @@
 const currentDataTimeIso = () => new Date().toISOString()
 
-const successfulTransactionResponse = ({ transactionId, amount, counterparty, status, type }) => {
+const successfulTransactionResponse = ({ transactionId, amount, counterparty, status, type, fees, presentBalance, notes }) => {
   return {
     id: transactionId,
     amount: amount || 0,
@@ -8,7 +8,11 @@ const successfulTransactionResponse = ({ transactionId, amount, counterparty, st
     direction: type === 'offer' ? 'outgoing' : 'incoming',
     status,
     type,
-    timestamp: currentDataTimeIso
+    timestamp: currentDataTimeIso,
+    // NOTE: the following details are ONLY available in the 'completed transactions'...
+    fees: fees || 0,
+    presentBalance: presentBalance || 'no presentBalance provided',
+    notes: notes || 'none'
   }
 }
 

--- a/src/graphql-server/resolvers.js
+++ b/src/graphql-server/resolvers.js
@@ -22,6 +22,8 @@ export const resolvers = {
 
     hostPricing: () => HhaDnaInterface.hostPricing.get(),
 
+    holofuelUser: ({ agentId }) => HoloFuelDnaInterface.user.get(agentId),
+
     holofuelWaitingTransactions: () => HoloFuelDnaInterface.transactions.allWaiting(),
 
     holofuelActionableTransactions: () => HoloFuelDnaInterface.transactions.allActionable(),

--- a/src/graphql-server/resolvers.js
+++ b/src/graphql-server/resolvers.js
@@ -22,7 +22,7 @@ export const resolvers = {
 
     hostPricing: () => HhaDnaInterface.hostPricing.get(),
 
-    holofuelUser: ({ agentId }) => HoloFuelDnaInterface.user.get(agentId),
+    holofuelUser: (_, { agentId }) => HoloFuelDnaInterface.user.get({ agentId }),
 
     holofuelWaitingTransactions: () => HoloFuelDnaInterface.transactions.allWaiting(),
 

--- a/src/graphql-server/resolvers.test.js
+++ b/src/graphql-server/resolvers.test.js
@@ -66,6 +66,15 @@ describe('resolvers', () => {
         expect(mockHoloFuelInterface.ledger.get).toHaveBeenCalled()
       })
     })
+
+    describe('.holofuelUser', () => {
+      it('calls HoloFuelInterface.transactions.holofuelUser.get', async () => {
+        const agentId = 'HcSCIgoBpzRmvnvq538iqbu39h9whsr6agZa6c9WPh9xujkb4dXBydEPaikvc5r'
+        resolvers.Query.holofuelUser({ agentId })
+        await wait(0)
+        expect(mockHoloFuelInterface.user.get).toHaveBeenCalled()
+      })
+    })
   })
 
   describe('Mutation', () => {

--- a/src/graphql-server/resolvers.test.js
+++ b/src/graphql-server/resolvers.test.js
@@ -70,7 +70,7 @@ describe('resolvers', () => {
     describe('.holofuelUser', () => {
       it('calls HoloFuelInterface.transactions.holofuelUser.get', async () => {
         const agentId = 'HcSCIgoBpzRmvnvq538iqbu39h9whsr6agZa6c9WPh9xujkb4dXBydEPaikvc5r'
-        resolvers.Query.holofuelUser({ agentId })
+        resolvers.Query.holofuelUser(null, { agentId })
         await wait(0)
         expect(mockHoloFuelInterface.user.get).toHaveBeenCalled()
       })

--- a/src/graphql-server/schema.graphql
+++ b/src/graphql-server/schema.graphql
@@ -32,6 +32,11 @@ type HostPricing {
   pricePerUnit: String
 }
 
+type HoloFuelUser {
+  id: ID
+  nickname: String
+}
+
 enum TransactionType {
   offer
   request
@@ -57,7 +62,8 @@ type Transaction {
   type: TransactionType
   timestamp: String
   fees: Float
-  endingBalance: Float
+  presentBalance: Float
+  notes: String 
 }
 
 type Ledger {
@@ -79,6 +85,7 @@ type Query {
   holofuelWaitingTransactions: [Transaction]
   holofuelActionableTransactions: [Transaction]
   holofuelLedger: Ledger
+  holofuelUser(agentId: ID!): HolofuelUser
 }
 
 type Mutation {

--- a/src/graphql-server/schema.graphql
+++ b/src/graphql-server/schema.graphql
@@ -32,7 +32,7 @@ type HostPricing {
   pricePerUnit: String
 }
 
-type HoloFuelUser {
+type HolofuelUser {
   id: ID
   nickname: String
 }
@@ -85,7 +85,7 @@ type Query {
   holofuelWaitingTransactions: [Transaction]
   holofuelActionableTransactions: [Transaction]
   holofuelLedger: Ledger
-  holofuelUser(agentId: ID!): HolofuelUser
+  holofuelUser(agentId: String): HolofuelUser
 }
 
 type Mutation {

--- a/src/graphql/HolofuelCompleteTransactionsQuery.gql
+++ b/src/graphql/HolofuelCompleteTransactionsQuery.gql
@@ -8,6 +8,7 @@ query HolofuelCompleteTransactionsQuery {
     type
     timestamp
     fees
-    endingBalance
+    presentBalance
+    notes
   }
 }

--- a/src/graphql/HolofuelUserQuery.gql
+++ b/src/graphql/HolofuelUserQuery.gql
@@ -1,0 +1,6 @@
+query HolofuelUser($id: ID!) {
+  holofuelUser(id: $id) {
+    id
+    nickname
+  }
+}

--- a/src/graphql/HolofuelUserQuery.gql
+++ b/src/graphql/HolofuelUserQuery.gql
@@ -1,5 +1,5 @@
-query HolofuelUser($id: ID!) {
-  holofuelUser(id: $id) {
+query HolofuelUser($agentId: String) {
+  holofuelUser(agentId: $agentId) {
     id
     nickname
   }

--- a/src/mock-dnas/holofuel.js
+++ b/src/mock-dnas/holofuel.js
@@ -60,6 +60,9 @@ export const transactionList = {
         },
         fees: {
           Ok: '0'
+        },
+        resulting_balance: {
+          Ok: 'This endpoint is a WIP'
         }
       }
     },
@@ -111,6 +114,9 @@ export const transactionList = {
         },
         fees: {
           Ok: '0'
+        },
+        resulting_balance: {
+          Ok: 'This endpoint is a WIP'
         }
       }
     },
@@ -157,6 +163,9 @@ export const transactionList = {
         },
         fees: {
           Ok: '0'
+        },
+        resulting_balance: {
+          Ok: 'This endpoint is a WIP'
         }
       }
     },
@@ -194,6 +203,9 @@ export const transactionList = {
         },
         fees: {
           Ok: '0'
+        },
+        resulting_balance: {
+          Ok: 'This endpoint is a WIP'
         }
       }
     },
@@ -228,6 +240,9 @@ export const transactionList = {
         },
         fees: {
           Ok: '0'
+        },
+        resulting_balance: {
+          Ok: 'This endpoint is a WIP'
         }
       }
     }
@@ -286,15 +301,23 @@ export const pendingList = {
   ]
 }
 
-const whoamiObj = {
-  nick: 'HoloFuel Magician',
-  pub_sign_key: 'HcSCIgoBpzRmvnvq538iqbu39h9whsr6agZa6c9WPh9xujkb4dXBydEPaikvc5r'
-}
+const agents = [
+  {
+    nick: 'Perry',
+    pub_sign_key: 'HcSCIgoBpzRmvnvq538iqbu39h9whsr6agZa6c9WPh9xujkb4dXBydEPaikvc5r'
+  },
+  {
+    nick: 'Sam',
+    pub_sign_key: 'HcScic3VAmEP9ucmrw4MMFKVARIvvdn43k6xi3d75PwnOswdaIE3BKFEUr3eozi'
+  }
+]
+
+const whoamiObj = (agentId) => agents.find(agent => agent.pub_sign_key === agentId) || { error: 'No agent was found by this id.' }
 
 const NUM_SALT_ROUNDS = 10
 const holofuel = {
   transactions: {
-    whoami: ({ agentId }) => whoamiObj,
+    whoami: ({ agentId }) => agentId ? whoamiObj(agentId) : agents[0],
     ledger_state: () => transactionList.ledger,
     list_transactions: () => transactionList,
     list_pending: () => pendingList,

--- a/src/mock-dnas/holofuel.js
+++ b/src/mock-dnas/holofuel.js
@@ -62,7 +62,8 @@ export const transactionList = {
           Ok: '0'
         },
         resulting_balance: {
-          Ok: 'This endpoint is a WIP'
+          // 'This endpoint is a WIP'
+          Ok: '0'
         }
       }
     },
@@ -116,7 +117,8 @@ export const transactionList = {
           Ok: '0'
         },
         resulting_balance: {
-          Ok: 'This endpoint is a WIP'
+          // 'This endpoint is a WIP'
+          Ok: '0'
         }
       }
     },
@@ -165,7 +167,8 @@ export const transactionList = {
           Ok: '0'
         },
         resulting_balance: {
-          Ok: 'This endpoint is a WIP'
+          // 'This endpoint is a WIP'
+          Ok: '0'
         }
       }
     },
@@ -205,7 +208,8 @@ export const transactionList = {
           Ok: '0'
         },
         resulting_balance: {
-          Ok: 'This endpoint is a WIP'
+          // 'This endpoint is a WIP'
+          Ok: '0'
         }
       }
     },
@@ -242,7 +246,8 @@ export const transactionList = {
           Ok: '0'
         },
         resulting_balance: {
-          Ok: 'This endpoint is a WIP'
+          // 'This endpoint is a WIP'
+          Ok: '0'
         }
       }
     }

--- a/src/mock-dnas/holofuel.js
+++ b/src/mock-dnas/holofuel.js
@@ -286,9 +286,15 @@ export const pendingList = {
   ]
 }
 
+const whoamiObj = {
+  nick: 'HoloFuel Magician',
+  pub_sign_key: 'HcSCIgoBpzRmvnvq538iqbu39h9whsr6agZa6c9WPh9xujkb4dXBydEPaikvc5r'
+}
+
 const NUM_SALT_ROUNDS = 10
 const holofuel = {
   transactions: {
+    whoami: ({ agentId }) => whoamiObj,
     ledger_state: () => transactionList.ledger,
     list_transactions: () => transactionList,
     list_pending: () => pendingList,


### PR DESCRIPTION
Updates the HF data layer to include the following updates : 
 - whoami endpoint updates - now accepts an opt. agentId (aka. agent pubkey) param that will return the matching nick
- accept_request gql query - now calls the updated dna endpoint 'accept_requests_pending', which officially accepts the origin hash as the id
- resulting_balance key within adjustment obj is mocked for each transaction returned from list_transactions endpoint.  This is currently a WIP in the DNA.