### PR TITLE
use renderAndWait in inbox.test

### DIFF
--- a/src/holofuel/pages/Inbox/Inbox.test.js
+++ b/src/holofuel/pages/Inbox/Inbox.test.js
@@ -1,6 +1,5 @@
 import React from 'react'
-import Modal from 'react-modal'
-import { render, fireEvent, act, within } from '@testing-library/react'
+import { fireEvent, act, within } from '@testing-library/react'
 import wait from 'waait'
 import { ApolloProvider } from '@apollo/react-hooks'
 import { MockedProvider } from '@apollo/react-testing'
@@ -10,6 +9,7 @@ import Inbox, { TransactionRow, RenderNickname } from './Inbox'
 import { pendingList } from 'mock-dnas/holofuel'
 import { TYPE } from 'models/Transaction'
 import { presentAgentId, presentHolofuelAmount } from 'utils'
+import { renderAndWait } from 'utils/test-utils'
 import HolofuelOfferMutation from 'graphql/HolofuelOfferMutation.gql'
 import HolofuelAcceptOfferMutation from 'graphql/HolofuelAcceptOfferMutation.gql'
 import HolofuelDeclineMutation from 'graphql/HolofuelDeclineMutation.gql'
@@ -40,14 +40,10 @@ jest.mock('holofuel/contexts/useFlashMessageContext')
 
 describe('Inbox Connected (with Agent Nicknames)', () => {
   it('renders', async () => {
-    let getAllByRole
 
-    await act(async () => {
-      ({ getAllByRole } = render(<ApolloProvider client={apolloClient}>
-        <Inbox />
-      </ApolloProvider>))
-      await wait(15)
-    })
+    const { getAllByRole } = await renderAndWait(<ApolloProvider client={apolloClient}>
+      <Inbox />
+    </ApolloProvider>, 15)
 
     const listItems = getAllByRole('listitem')
     expect(listItems).toHaveLength(2)
@@ -84,13 +80,9 @@ describe('TransactionRow', () => {
   }
 
   it('renders a request', async () => {
-    let getByText
-    await act(async () => {
-      ({ getByText } = render(<MockedProvider addTypename={false}>
-        <TransactionRow transaction={request} />
-      </MockedProvider>))
-      await wait(0)
-    })
+    const { getByText } = await renderAndWait(<MockedProvider addTypename={false}>
+      <TransactionRow transaction={request} />
+    </MockedProvider>, 0)
 
     expect(getByText(request.timestamp.format('MMM D YYYY'))).toBeInTheDocument()
     expect(getByText(request.timestamp.utc().format('kk:mm UTC'))).toBeInTheDocument()
@@ -102,13 +94,9 @@ describe('TransactionRow', () => {
   })
 
   it('renders an offer', async () => {
-    let getByText
-    await act(async () => {
-      ({ getByText } = render(<MockedProvider addTypename={false}>
-        <TransactionRow transaction={offer} />
-      </MockedProvider>))
-      await wait(0)
-    })
+    const { getByText } = await renderAndWait(<MockedProvider addTypename={false}>
+      <TransactionRow transaction={offer} />
+    </MockedProvider>, 0)
 
     expect(getByText(request.timestamp.format('MMM D YYYY'))).toBeInTheDocument()
     expect(getByText(request.timestamp.utc().format('kk:mm UTC'))).toBeInTheDocument()
@@ -180,13 +168,9 @@ describe('TransactionRow', () => {
         transaction: request,
         showConfirmationModal: jest.fn()
       }
-      let getByText
-      await act(async () => {
-        ({ getByText } = render(<MockedProvider mocks={mocks} addTypename={false}>
-          <TransactionRow {...props} />
-        </MockedProvider>))
-        await wait(0)
-      })
+      const { getByText } = await renderAndWait(<MockedProvider mocks={mocks} addTypename={false}>
+        <TransactionRow {...props} />
+      </MockedProvider>, 0)
 
       await act(async () => {
         fireEvent.click(getByText('Pay'))
@@ -203,13 +187,9 @@ describe('TransactionRow', () => {
 
   describe('Accept button', () => {
     it('responds properly', async () => {
-      let getByText
-      await act(async () => {
-        ({ getByText } = render(<MockedProvider mocks={mocks} addTypename={false}>
-          <TransactionRow transaction={offer} />
-        </MockedProvider>))
-        await wait(0)
-      })
+      const { getByText } = await renderAndWait(<MockedProvider mocks={mocks} addTypename={false}>
+        <TransactionRow transaction={offer} />
+      </MockedProvider>, 0)
 
       await act(async () => {
         fireEvent.click(getByText('Accept'))
@@ -260,14 +240,9 @@ describe('TransactionRow', () => {
       counterpartyQueryMockError
     ]
 
-    let container, getByText
-    await act(async () => {
-      ({ container, getByText } = render(<MockedProvider mocks={mocks} addTypename={false}>
-        <RenderNickname agentId={rowContent.counterparty} className='mock-style' />
-      </MockedProvider>))
-      await wait(0)
-      Modal.setAppElement(container)
-    })
+    const { getByText } = await renderAndWait(<MockedProvider mocks={mocks} addTypename={false}>
+      <RenderNickname agentId={rowContent.counterparty} className='mock-style' />
+    </MockedProvider>, 0)
 
     const nameDiv = getByText(presentAgentId(rowContent.counterparty))
     expect(nameDiv).toBeInTheDocument()

--- a/src/utils/test-utils.js
+++ b/src/utils/test-utils.js
@@ -1,0 +1,11 @@
+import { render, act } from '@testing-library/react'
+import wait from 'waait'
+
+export async function renderAndWait (ui, ms = 0, options = {}) {
+  let queries
+  await act(async () => {
+    queries = render(ui, options)
+    await wait(ms)
+  })
+  return queries
+}


### PR DESCRIPTION
@JettTech  - What do you think? I think it improves readability of the tests considerably. I just did it in `inbox.test`, but there's a chore to do it everywhere else.