### PR TITLE
Rename test:all to test:ci

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -9,7 +9,7 @@ let
   ''
     ( rm -rf node_modules  ) \
     &&  npm install --build-from-source  \
-    && npm run test:all
+    && npm run test:ci
   '';
 
   build-hp-admin = pkgs.writeShellScriptBin "build-hp-admin"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:unit": "node scripts/test.js --config=./jest.unit.config.js",
     "test:integration-with-setup": "nix-shell --run 'node scripts/wait-for-conductor.js && npm run test:integration'",
     "test:integration": "REACT_APP_INTEGRATION_TEST=true node scripts/test.js --config=./jest.integration.config.js",
-    "test:all": "CI=1 npm run test"
+    "test:ci": "CI=1 npm run test"
   },
   "dependencies": {
     "@apollo/react-hoc": "^3.0.1",


### PR DESCRIPTION
@zo-el I want to change this back because our CI script expects this script to be called `test:ci`

Will this break anything that you're doing?