### PR TITLE
Updated the holo-nixpkgs to the latest release

### DIFF
--- a/config.nix
+++ b/config.nix
@@ -9,13 +9,6 @@
     keystore_file = "agent.key";
     public_address = "HcScIio76M8cbDqhrsZKp37W8YZ4y8X9v9epzbyhRzqpjeb5sigdC4puN6b5koi";
   }
-  # Currently we can only run one agent on a conductor
-  #{
-  #  id = "hp-admin-agent-2";
-  #  name = "HP Admin 2";
-  #  keystore_file = "agent-2.key";
-  #  public_address = "HcScjSPMA9g46x6nosEih9thqwvesx53udZEkqMfqcwnbw9sZKPSyIFNvtfxrqi";
-  #}
   ];
 
 }

--- a/config.nix
+++ b/config.nix
@@ -9,11 +9,13 @@
     keystore_file = "agent.key";
     public_address = "HcScIio76M8cbDqhrsZKp37W8YZ4y8X9v9epzbyhRzqpjeb5sigdC4puN6b5koi";
   }
-  {
-    id = "hp-admin-agent-2";
-    name = "HP Admin 2";
-    keystore_file = "agent-2.key";
-    public_address = "HcScjSPMA9g46x6nosEih9thqwvesx53udZEkqMfqcwnbw9sZKPSyIFNvtfxrqi";
-  }];
+  # Currently we can only run one agent on a conductor
+  #{
+  #  id = "hp-admin-agent-2";
+  #  name = "HP Admin 2";
+  #  keystore_file = "agent-2.key";
+  #  public_address = "HcScjSPMA9g46x6nosEih9thqwvesx53udZEkqMfqcwnbw9sZKPSyIFNvtfxrqi";
+  #}
+  ];
 
 }

--- a/pkgs.nix
+++ b/pkgs.nix
@@ -1,4 +1,4 @@
 import (fetchTarball {
-  url = "https://github.com/Holo-Host/holo-nixpkgs/archive/c4ed4fbf07d74cbbcaec5a338e062c3114b7a825.tar.gz";
-  sha256 = "0sqjcqj6c862lilxb4siwm1rxi2bp8042r1bh1k4xc7gi5c2igvf";
+  url = "https://github.com/Holo-Host/holo-nixpkgs/archive/b13306ced23e81bc7b05dfa16cd929d8c1789e7d.tar.gz";
+  sha256 = "0s1c8k9njsjdfryidbb7mxpqvsy91pm2387hmgpxa8h8jc4hwyn2";
 })

--- a/shell.nix
+++ b/shell.nix
@@ -14,8 +14,6 @@ mkShell {
     rm -f src/utils/integration-testing/conductor-config.toml
     ln -s ${project.hp-admin-conductor-config} conductor-config.toml
     ln -s ${project.hp-admin-conductor-config} src/utils/integration-testing/conductor-config.toml
-    cleanup() {
-    }
     trap cleanup EXIT
   '';
 }


### PR DESCRIPTION
- hc Version 0.0.34-alpha4
- removed agent2 from config.nix because you can only have one agent on a conductor according to current settings.

> Note: We should talk about setting up two conductors for this repo. And plans to use `hc run` cmd