### PR TITLE
Bug fix cancel and decline promises

### DIFF
--- a/src/data-interfaces/HoloFuelDnaInterface.js
+++ b/src/data-interfaces/HoloFuelDnaInterface.js
@@ -256,8 +256,6 @@ const HoloFuelDnaInterface = {
       const { transactions } = await createZomeCall('transactions/list_transactions')({ state: stateFilter })
       const listOfNonActionableTransactions = transactions.map(presentTransaction)
       const cleanedList = _.uniqBy(listOfNonActionableTransactions, 'origin')
-      console.log('cleanedList : ', cleanedList)
-
       if (cleanedList.length === 0) {
         console.error(`No pending transaction with id ${transactionId} found.`)
       } else {
@@ -322,7 +320,7 @@ const HoloFuelDnaInterface = {
     },
     /* NOTE: cancel WAITING TRANSACTION that current agent authored (or ACTIONABLE ACCEPT that agent received... ???). */
     cancel: async (transactionId) => {
-      const authoredRequests = await HoloFuelDnaInterface.transactions.allNonActionableByState(transactionId, ['incoming/requested'], 'canceled')
+      const authoredRequests = await HoloFuelDnaInterface.transactions.allNonActionableByState(transactionId, ['incoming/requested','outgoing/approved'], 'canceled')
       const transaction = authoredRequests.find(authoredRequest => authoredRequest.origin === transactionId)
 
       console.log(' CANCEL TRANSACTION DETAILS : ', transaction)

--- a/src/data-interfaces/HoloFuelDnaInterface.js
+++ b/src/data-interfaces/HoloFuelDnaInterface.js
@@ -318,7 +318,7 @@ const HoloFuelDnaInterface = {
     },
     /* NOTE: cancel WAITING TRANSACTION that current agent authored (or ACTIONABLE ACCEPT that agent received... ???). */
     cancel: async (transactionId) => {
-      const authoredRequests = await HoloFuelDnaInterface.transactions.allNonActionableByState(transactionId, ['incoming/requested','outgoing/approved'], 'canceled')
+      const authoredRequests = await HoloFuelDnaInterface.transactions.allNonActionableByState(transactionId, ['incoming/requested', 'outgoing/approved'], 'canceled')
       const transaction = authoredRequests.find(authoredRequest => authoredRequest.origin === transactionId)
 
       console.log(' CANCEL TRANSACTION DETAILS : ', transaction)

--- a/src/data-interfaces/HoloFuelDnaInterface.js
+++ b/src/data-interfaces/HoloFuelDnaInterface.js
@@ -308,7 +308,9 @@ const HoloFuelDnaInterface = {
     /* NOTE: decline ACTIONABLE TRANSACTION (NB: pending transaction proposed by another agent) >> ONLY for on asynchronous transactions. */
     decline: async (transactionId) => {
       const transaction = await HoloFuelDnaInterface.transactions.getPending(transactionId)
-      const declinedProof = await createZomeCall('transactions/decline_pending')({ origins: transactionId })
+      // NOTE: POTENTIAL DNA BUG >> Passing in a reason to the `decline_pending` endpoint generates API error.
+      // const reason = annulTransactionReason
+      const declinedProof = await createZomeCall('transactions/decline_pending')({ origins: transactionId }) // ({ origins: transactionId, reason })
       return {
         ...transaction,
         id: transactionId,

--- a/src/data-interfaces/HoloFuelDnaInterface.js
+++ b/src/data-interfaces/HoloFuelDnaInterface.js
@@ -308,9 +308,7 @@ const HoloFuelDnaInterface = {
     /* NOTE: decline ACTIONABLE TRANSACTION (NB: pending transaction proposed by another agent) >> ONLY for on asynchronous transactions. */
     decline: async (transactionId) => {
       const transaction = await HoloFuelDnaInterface.transactions.getPending(transactionId)
-      const reason = annulTransactionReason
-      const declinedProof = await createZomeCall('transactions/decline_pending')({ origins: transactionId, reason })
-
+      const declinedProof = await createZomeCall('transactions/decline_pending')({ origins: transactionId })
       return {
         ...transaction,
         id: transactionId,

--- a/src/data-interfaces/HoloFuelDnaInterface.js
+++ b/src/data-interfaces/HoloFuelDnaInterface.js
@@ -238,7 +238,7 @@ const HoloFuelDnaInterface = {
     },
     allActionable: async () => {
       const { requests, promises, declined, canceled } = await createZomeCall('transactions/list_pending')()
-      const actionableTransactions = requests.map(presentPendingRequest).concat(promises.map(presentPendingOffer)).concat(declined.map(presentDeclinedTransaction)).concat(canceled.map(presentCanceledTransaction))
+      const actionableTransactions = requests.map(r=>presentPendingRequest(r)).concat(promises.map(p=>presentPendingOffer(p))).concat(declined.map(presentDeclinedTransaction)).concat(canceled.map(presentCanceledTransaction))
 
       console.log('ALL ACTIONABLE TRANSACTIONS : ', actionableTransactions.sort((a, b) => a.timestamp > b.timestamp ? -1 : 1))
 
@@ -276,7 +276,7 @@ const HoloFuelDnaInterface = {
     },
     getPending: async (transactionId) => {
       const { requests, promises } = await createZomeCall('transactions/list_pending')({ origins: transactionId })
-      const transactionArray = requests.map(presentPendingRequest).concat(promises.map(presentPendingOffer))
+      const transactionArray = requests.map(r=>presentPendingRequest(r)).concat(promises.map(p=>presentPendingOffer(p)))
       if (transactionArray.length === 0) {
         throw new Error(`no pending transaction with id ${transactionId} found.`)
       } else {

--- a/src/data-interfaces/HoloFuelDnaInterface.js
+++ b/src/data-interfaces/HoloFuelDnaInterface.js
@@ -238,7 +238,7 @@ const HoloFuelDnaInterface = {
     },
     allActionable: async () => {
       const { requests, promises, declined, canceled } = await createZomeCall('transactions/list_pending')()
-      const actionableTransactions = requests.map(r=>presentPendingRequest(r)).concat(promises.map(p=>presentPendingOffer(p))).concat(declined.map(presentDeclinedTransaction)).concat(canceled.map(presentCanceledTransaction))
+      const actionableTransactions = requests.map(r => presentPendingRequest(r)).concat(promises.map(p => presentPendingOffer(p))).concat(declined.map(presentDeclinedTransaction)).concat(canceled.map(presentCanceledTransaction))
 
       console.log('ALL ACTIONABLE TRANSACTIONS : ', actionableTransactions.sort((a, b) => a.timestamp > b.timestamp ? -1 : 1))
 
@@ -276,7 +276,7 @@ const HoloFuelDnaInterface = {
     },
     getPending: async (transactionId) => {
       const { requests, promises } = await createZomeCall('transactions/list_pending')({ origins: transactionId })
-      const transactionArray = requests.map(r=>presentPendingRequest(r)).concat(promises.map(p=>presentPendingOffer(p)))
+      const transactionArray = requests.map(r => presentPendingRequest(r)).concat(promises.map(p => presentPendingOffer(p)))
       if (transactionArray.length === 0) {
         throw new Error(`no pending transaction with id ${transactionId} found.`)
       } else {

--- a/src/holofuel/pages/TransactionHistory/TransactionHistory.js
+++ b/src/holofuel/pages/TransactionHistory/TransactionHistory.js
@@ -53,10 +53,9 @@ function useTransactionsWithCounterparties () {
     ...transaction,
     counterparty: counterparties.find(counterparty => {
       if (transactions.counterparty != null) {
-        return counterparty.id === transaction.counterparty.id}
-      else return false
-    }
-  ) || transaction.counterparty
+        return counterparty.id === transaction.counterparty.id
+      } else return false
+    }) || transaction.counterparty
   }))
 
   const allCounterparties = uniqBy('id', holofuelHistoryCounterparties.concat([whoami]))
@@ -138,10 +137,10 @@ export default function TransactionsHistory () {
         { // Filtered to remove all the cancled transactions
           // TODO: Display the Cancled transactions.
           (transactions.filter(t => t.counterparty)).map((transaction, index) => <TransactionRow
-          transaction={transaction}
-          key={transaction.id}
-          showCancellationModal={showCancellationModal}
-          isFirst={index === 0} />)}
+            transaction={transaction}
+            key={transaction.id}
+            showCancellationModal={showCancellationModal}
+            isFirst={index === 0} />)}
       </React.Fragment>)}
     </div>}
 
@@ -216,8 +215,8 @@ export function ConfirmCancellationModal ({ transaction, handleClose, cancelTran
   if (!transaction) return null
   const { id, counterparty, amount, type, direction } = transaction
   const onYes = () => {
-    if (TYPE.request) {console.log("REQUEST CANCLE: ");cancelTransaction(id)}
-    else if (TYPE.offer) {console.log("REFUND CANCLE: ");refundTransaction(id)}
+    if (TYPE.request) cancelTransaction(id)
+    else if (TYPE.offer) refundTransaction(id)
     else console.error('Detected invalid Transaction Type; could not progress with cancel.')
     handleClose()
   }

--- a/src/holofuel/pages/TransactionHistory/TransactionHistory.js
+++ b/src/holofuel/pages/TransactionHistory/TransactionHistory.js
@@ -134,8 +134,8 @@ export default function TransactionsHistory () {
     {!noVisibleTransactions && <div styleName='transactions'>
       {partitionedTransactions.map(({ label, transactions }) => <React.Fragment key={label}>
         <div styleName='partition-label'>{label}</div>
-        { // Filtered to remove all the cancled transactions
-          // TODO: Display the Cancled transactions.
+        { // Transactions filtered by counterparty to filter out all canceled transactions (which currenlty do not have a counterparty in the object...)
+          // TODO: Display the Canceled transactions.
           (transactions.filter(t => t.counterparty)).map((transaction, index) => <TransactionRow
             transaction={transaction}
             key={transaction.id}

--- a/src/holofuel/pages/TransactionHistory/TransactionHistory.js
+++ b/src/holofuel/pages/TransactionHistory/TransactionHistory.js
@@ -51,7 +51,12 @@ function useTransactionsWithCounterparties () {
 
   const updateCounterparties = (transactions, counterparties) => transactions.map(transaction => ({
     ...transaction,
-    counterparty: counterparties.find(counterparty => counterparty.id === transaction.counterparty.id) || transaction.counterparty
+    counterparty: counterparties.find(counterparty => {
+      if (transactions.counterparty != null) {
+        return counterparty.id === transaction.counterparty.id}
+      else return false
+    }
+  ) || transaction.counterparty
   }))
 
   const allCounterparties = uniqBy('id', holofuelHistoryCounterparties.concat([whoami]))
@@ -130,7 +135,9 @@ export default function TransactionsHistory () {
     {!noVisibleTransactions && <div styleName='transactions'>
       {partitionedTransactions.map(({ label, transactions }) => <React.Fragment key={label}>
         <div styleName='partition-label'>{label}</div>
-        {transactions.map((transaction, index) => <TransactionRow
+        { // Filtered to remove all the cancled transactions
+          // TODO: Display the Cancled transactions.
+          (transactions.filter(t => t.counterparty)).map((transaction, index) => <TransactionRow
           transaction={transaction}
           key={transaction.id}
           showCancellationModal={showCancellationModal}
@@ -209,8 +216,8 @@ export function ConfirmCancellationModal ({ transaction, handleClose, cancelTran
   if (!transaction) return null
   const { id, counterparty, amount, type, direction } = transaction
   const onYes = () => {
-    if (TYPE.request) cancelTransaction(id)
-    else if (TYPE.offer) refundTransaction(id)
+    if (TYPE.request) {console.log("REQUEST CANCLE: ");cancelTransaction(id)}
+    else if (TYPE.offer) {console.log("REFUND CANCLE: ");refundTransaction(id)}
     else console.error('Detected invalid Transaction Type; could not progress with cancel.')
     handleClose()
   }


### PR DESCRIPTION
This solves the bug for 
- canceling outgoing promises. 
- decline incoming promises

> Note: I have filtered to not to display the cancel transactions because they do not have counterparties and so it was throwing a bug. 
> TODO: Display the cancelled transaction.