### PR TITLE
fix word of button breaking into two lines

### DIFF
--- a/src/holofuel/pages/Inbox/Inbox.module.css
+++ b/src/holofuel/pages/Inbox/Inbox.module.css
@@ -267,6 +267,7 @@
   font-size: 10px;
   text-align: center;
   text-transform: capitalize;
+  word-break: keep-all;
 }
 
 .accept-button {


### PR DESCRIPTION
on firefox

before:
<img width="410" alt="Screen Shot 2020-03-30 at 2 06 37 PM" src="https://user-images.githubusercontent.com/1409121/77946212-f684a780-728f-11ea-85ae-69835217659c.png">
after:
<img width="398" alt="Screen Shot 2020-03-30 at 2 06 46 PM" src="https://user-images.githubusercontent.com/1409121/77946221-f84e6b00-728f-11ea-865a-1e476a679f75.png">

I double checked and chrome stays fine
