### PR TITLE
Decline message cases were mixed up

### DIFF
--- a/src/holofuel/pages/Inbox/Inbox.js
+++ b/src/holofuel/pages/Inbox/Inbox.js
@@ -418,8 +418,7 @@ function PayButton ({ showPayModal }) {
     onClick={showPayModal}
     styleName='accept-button'
   >
-    {/* NB: Not a typo. This is to 'Accept Request for Payment' */}
-    <p>Accept</p>
+    <p>Pay</p>
   </Button>
 }
 
@@ -457,7 +456,7 @@ export function ConfirmationModal ({ confirmationModalProperties, setConfirmatio
       actionParams = { id, amount, counterparty, notes }
       actionHook = payTransaction
       message = <>
-        Accept request for payment of {presentHolofuelAmount(amount)} TF from {counterparty.nickname || presentAgentId(counterparty.id)}?
+        Agree to pay {presentHolofuelAmount(amount)} TF to {counterparty.nickname || presentAgentId(counterparty.id)}?
       </>
       flashMessage = 'Payment sent succesfully'
       break
@@ -478,11 +477,11 @@ export function ConfirmationModal ({ confirmationModalProperties, setConfirmatio
       actionHook = declineTransaction
       if (type === 'offer') {
         message = <>
-          Decline request for payment of {presentHolofuelAmount(amount)} TF from {counterparty.nickname || presentAgentId(counterparty.id)}?
+          Decline offer of {presentHolofuelAmount(amount)} TF from {counterparty.nickname || presentAgentId(counterparty.id)}?
         </>
       } else {
         message = <>
-          Decline offer of {presentHolofuelAmount(amount)} TF from {counterparty.nickname || presentAgentId(counterparty.id)}?
+          Decline request for payment of {presentHolofuelAmount(amount)} TF from {counterparty.nickname || presentAgentId(counterparty.id)}?
         </>
       }
       flashMessage = `${type.replace(/^\w/, c => c.toUpperCase())} succesfully declined`


### PR DESCRIPTION
There are two things I've done in this PR...

1. fix the thing that I first noticed, which is that the messages for "Decline Confirmation" were mixed up between the "offer" and "request" transaction types. That was a simple switch

2. Made change proposals to the language use around "Accept request for payment". I don't think this has been thought about very hard, despite the code comment. I don't think it's been appreciated just how confusing/misleading this language is from an end-user perspective. It took someone as familiar as me with all of this a good one minute of reading and re-reading the messages to really make sense of them, and know what they were getting at. Not a good start for something as sensitive as sending out a payment. I made a change proposal to the language of "accept request for payment". I propose words such as "Agree", or "Pay", and also to use that language within the confirmation modal, so that it becomes "Agree to pay 124,500 TF to Sam?" No/Yes. 

Of course you can accept the first without the second change request, but I propose this, without some change, is guaranteed to cause user issues down the road.

Accept/Agree related before/after:

Before

<img width="401" alt="Screen Shot 2020-03-31 at 10 05 33 PM" src="https://user-images.githubusercontent.com/1409121/78091748-cde9d400-739b-11ea-93d5-d623af165157.png">

After

<img width="428" alt="Screen Shot 2020-03-31 at 9 55 15 PM" src="https://user-images.githubusercontent.com/1409121/78091754-d215f180-739b-11ea-8ce6-8f9b055b1b0c.png">




