### PR TITLE
propose use of "agent address" phrase instead of "agent hash" in user feedback message

### DIFF
--- a/src/holofuel/pages/CreateOfferRequest/CreateOfferRequest.js
+++ b/src/holofuel/pages/CreateOfferRequest/CreateOfferRequest.js
@@ -251,7 +251,7 @@ export function RenderNickname ({ agentId, setCounterpartyNick, setCounterpartyF
     if (!loading) {
       if (!id) {
         setCounterpartyFound(false)
-        newMessage('This HoloFuel Peer is currently unable to be located in the network. \n Please verify the hash of your HoloFuel Peer and try again.')
+        newMessage('This HoloFuel Peer is currently unable to be located in the network. \n Please verify the address of your HoloFuel Peer and try again.')
       } else {
         setCounterpartyFound(true)
       }


### PR DESCRIPTION
I would propose this because it will be more intuitive for people to consider this an address, than a hash, which is valid even in terms of internal terminology too, where hash and address are used interchangeably