### PR TITLE
D-01068 - Accepted Requests appear as type request instead of as type offer

### DIFF
--- a/src/data-interfaces/HoloFuelDnaInterface.js
+++ b/src/data-interfaces/HoloFuelDnaInterface.js
@@ -415,7 +415,7 @@ const HoloFuelDnaInterface = {
       const origin = await createZomeCall('transactions/promise')(pickBy(i => i, { to: counterpartyId, amount: amount.toString(), deadline: mockDeadline(), notes, request: requestId }))
 
       return {
-        id: requestId || origin, // NB: If requestId isn't defined, then offer use origin as the ID (ie. Offer is the initiating transaction).
+        id: requestId || origin, // NB: If requestId isn't defined, then offer uses origin as the ID (ie. Offer is the initiating transaction).
         amount,
         counterparty: {
           id: counterpartyId
@@ -423,7 +423,7 @@ const HoloFuelDnaInterface = {
         notes,
         direction: DIRECTION.outgoing, // this indicates the hf spender
         status: STATUS.pending,
-        type: TYPE.offer,
+        type: requestId ? TYPE.request : TYPE.offer, // NB: If requestId isn't defined, then base transaction is an offer, otherwise, it's a request user is paying
         timestamp: currentDataTimeIso
       }
     },

--- a/src/holofuel/components/SideMenu/SideMenu.js
+++ b/src/holofuel/components/SideMenu/SideMenu.js
@@ -102,7 +102,7 @@ export default function SideMenu ({
 }
 
 function DisplayBalance ({ ledgerLoading, holofuelBalance }) {
-  if (ledgerLoading) return <>-- TF</>
+  if (ledgerLoading || isNaN(holofuelBalance)) return <>-- TF</>
   else return <>{presentHolofuelAmount(holofuelBalance)} TF</>
 }
 

--- a/src/holofuel/components/layout/PrimaryLayout/PrimaryLayout.js
+++ b/src/holofuel/components/layout/PrimaryLayout/PrimaryLayout.js
@@ -21,7 +21,7 @@ import { wsConnection } from 'holochainClient'
 import styles from './PrimaryLayout.module.css' // eslint-disable-line no-unused-vars
 import 'holofuel/global-styles/colors.css'
 import 'holofuel/global-styles/index.css'
-import { useInterval } from 'utils'
+import { useInterval, useLoadingFirstTime } from 'utils'
 
 function PrimaryLayout ({
   children,
@@ -86,6 +86,7 @@ function PrimaryLayout ({
     shouldRefetchUser,
     refetchHolofuelUser])
 
+  const isLoadingFirstLedger = useLoadingFirstTime(ledgerLoading)
   const inboxCount = actionableTransactions.filter(shouldShowTransactionInInbox).length
   const isWide = useContext(ScreenWidthContext)
   const [isMenuOpen, setMenuOpen] = useState(false)
@@ -101,7 +102,7 @@ function PrimaryLayout ({
       agentLoading={currentUserLoading}
       inboxCount={inboxCount}
       holofuelBalance={holofuelBalance}
-      ledgerLoading={ledgerLoading}
+      ledgerLoading={isLoadingFirstLedger}
       isWide={isWide} />
     {showAlphaFlag && <AlphaFlag styleName='styles.alpha-flag' />}
     <div styleName={cx('styles.content')}>

--- a/src/holofuel/pages/Home/Home.js
+++ b/src/holofuel/pages/Home/Home.js
@@ -19,7 +19,7 @@ import { caribbeanGreen } from 'utils/colors'
 import { OFFER_REQUEST_PATH, HISTORY_PATH } from 'holofuel/utils/urls'
 
 const DisplayBalance = ({ ledgerLoading, holofuelBalance }) => {
-  if (ledgerLoading || !holofuelBalance) return <>-- TF</>
+  if (ledgerLoading || isNaN(holofuelBalance)) return <>-- TF</>
   else return <>{presentHolofuelAmount(holofuelBalance)} TF</>
 }
 

--- a/src/holofuel/pages/Inbox/Inbox.js
+++ b/src/holofuel/pages/Inbox/Inbox.js
@@ -259,7 +259,6 @@ export function Partition ({ dateLabel, transactions, userId, setConfirmationMod
 
 export function TransactionRow ({ transaction, setConfirmationModalProperties, isActionable, userId, hideTransaction, areActionsPaused, setAreActionsPaused, openDrawerId, setOpenDrawerId, showUserMessage }) {
   const { id, counterparty, amount, type, status, direction, notes, canceledBy, isPayingARequest, inProcess } = transaction
-
   if (inProcess && userNotification) {
     showUserMessage()
   }
@@ -443,7 +442,7 @@ function ActionOptions ({ isOffer, isRequest, transaction, showAcceptModal, show
   </aside>
 }
 
-function AmountCell ({ amount, isRequest, isOffer, isActionable, isOutgoing, isCanceled, isDeclined }) {
+function AmountCell ({ amount, isRequest, isOffer, isActionable, isOutgoing, isCanceled, isDeclined }) {  
   let amountDisplay
   if (isActionable) {
     amountDisplay = isRequest ? `(${presentTruncatedAmount(presentHolofuelAmount(amount), 15)})` : presentTruncatedAmount(presentHolofuelAmount(amount), 15)

--- a/src/holofuel/pages/Inbox/Inbox.js
+++ b/src/holofuel/pages/Inbox/Inbox.js
@@ -442,7 +442,7 @@ function ActionOptions ({ isOffer, isRequest, transaction, showAcceptModal, show
   </aside>
 }
 
-function AmountCell ({ amount, isRequest, isOffer, isActionable, isOutgoing, isCanceled, isDeclined }) {  
+function AmountCell ({ amount, isRequest, isOffer, isActionable, isOutgoing, isCanceled, isDeclined }) {
   let amountDisplay
   if (isActionable) {
     amountDisplay = isRequest ? `(${presentTruncatedAmount(presentHolofuelAmount(amount), 15)})` : presentTruncatedAmount(presentHolofuelAmount(amount), 15)


### PR DESCRIPTION
### Updates :
- corrects createOfferMutation returned transaction types
- handles balance rendering bug in sidebar (no longer flashes '--' following new poll to ledgerQuery)

## To Test : 
 - spin up two agents (ui and conductors) plus sim2h
 - create request from agent1 to agent2
 - have agent2 accept the request
 - notice that upon successful acceptance, the amount remains negative (ie: it is colored red and encased in the parentheses)