### PR TITLE
Accepted transactions optimistic rending

### DIFF
--- a/src/data-interfaces/HoloFuelDnaInterface.js
+++ b/src/data-interfaces/HoloFuelDnaInterface.js
@@ -45,11 +45,12 @@ const presentRequest = ({ origin, event, stateDirection, eventTimestamp, counter
     timestamp: eventTimestamp,
     notes: notes || event.Request.notes,
     fees,
-    isPayingARequest
+    isPayingARequest,
+    actioned: false
   }
 }
 
-const presentOffer = ({ origin, event, stateDirection, eventTimestamp, counterpartyId, amount, notes, fees, status, isPayingARequest = false, inProcess }) => {
+const presentOffer = ({ origin, event, stateDirection, eventTimestamp, counterpartyId, amount, notes, fees, status, isPayingARequest = false, inProcess = false }) => {
   return {
     id: origin,
     amount: amount || event.Promise.tx.amount,
@@ -63,7 +64,8 @@ const presentOffer = ({ origin, event, stateDirection, eventTimestamp, counterpa
     notes: notes || event.Promise.tx.notes,
     fees,
     isPayingARequest,
-    inProcess
+    inProcess,
+    actioned: false
   }
 }
 
@@ -442,7 +444,8 @@ const HoloFuelDnaInterface = {
               id: transactionId, // should always match `Object.entries(result)[0][0]`
               direction: DIRECTION.incoming, // this indicates the hf recipient
               status: STATUS.pending,
-              type: TYPE.offer
+              type: TYPE.offer,
+              actioned: true
             }
           } else if (JSON.parse(acceptedPaymentHash.Err.Internal).kind.Timeout) {
             return {
@@ -450,7 +453,8 @@ const HoloFuelDnaInterface = {
               id: transactionId, // should always match `Object.entries(result)[0][0]`
               direction: DIRECTION.incoming, // this indicates the hf recipient
               status: STATUS.pending,
-              type: TYPE.offer
+              type: TYPE.offer,
+              actioned: true
             }
           }
         } else {
@@ -462,7 +466,8 @@ const HoloFuelDnaInterface = {
         id: transactionId, // should always match `Object.entries(result)[0][0]`
         direction: DIRECTION.incoming, // this indicates the hf recipient
         status: STATUS.completed,
-        type: TYPE.offer
+        type: TYPE.offer,
+        actioned: true
       }
     }
   }

--- a/src/data-interfaces/HoloFuelDnaInterface.js
+++ b/src/data-interfaces/HoloFuelDnaInterface.js
@@ -445,7 +445,7 @@ const HoloFuelDnaInterface = {
               direction: DIRECTION.incoming, // this indicates the hf recipient
               status: STATUS.pending,
               type: TYPE.offer,
-              actioned: true
+              actioned: false
             }
           } else if (JSON.parse(acceptedPaymentHash.Err.Internal).kind.Timeout) {
             return {

--- a/src/graphql-server/schema.graphql
+++ b/src/graphql-server/schema.graphql
@@ -71,6 +71,7 @@ type Transaction {
   canceledBy: HolofuelUser
   isPayingARequest: Boolean
   inProcess: Boolean
+  actioned: Boolean
 }
 
 type Ledger {

--- a/src/graphql/HolofuelAcceptOfferMutation.gql
+++ b/src/graphql/HolofuelAcceptOfferMutation.gql
@@ -7,5 +7,6 @@ mutation HolofuelAcceptOfferMutation ($transactionId: ID) {
     status
     type
     timestamp
+    actioned
   }
 }

--- a/src/graphql/HolofuelActionableTransactionsQuery.gql
+++ b/src/graphql/HolofuelActionableTransactionsQuery.gql
@@ -12,5 +12,6 @@ query HolofuelActionableTransactionsQuery {
     isPayingARequest
     canceledBy { id, nickname }
     inProcess
+    actioned
   }
 }

--- a/src/holofuel/components/ToolTip/ToolTip.js
+++ b/src/holofuel/components/ToolTip/ToolTip.js
@@ -5,7 +5,6 @@ import './ToolTip.module.css'
 import { caribbeanGreen } from 'utils/colors'
 
 export default function ToolTip ({ toolTipText, children }) {
-  console.log('timeoutErrorMessage : ', toolTipText)
   return <>
     <span data-tip='' data-for='registerTip'>
       {children}

--- a/src/holofuel/pages/Inbox/Inbox.js
+++ b/src/holofuel/pages/Inbox/Inbox.js
@@ -396,7 +396,7 @@ export function TransactionRow ({ transaction, setConfirmationModalProperties, i
       <h4 styleName='alert-msg'>{offerInProcessMessage}</h4>
     </ToolTip>}
 
-    {isActionable && !isLoading && !isDisabled && !inProcess && <>
+    {isActionable && !isLoading && !isDisabled && <>
       <RevealActionsButton
         isDrawerOpen={isDrawerOpen}
         openDrawer={() => setIsDrawerOpen(true)}

--- a/src/holofuel/pages/Inbox/Inbox.js
+++ b/src/holofuel/pages/Inbox/Inbox.js
@@ -115,7 +115,7 @@ const presentTruncatedAmount = (string, number = 15) => {
 }
 
 export default function Inbox ({ history: { push } }) {
-  const { loading: ledgerLoading, data: { holofuelLedger: { balance: holofuelBalance } = {} } = {} } = useQuery(HolofuelLedgerQuery, { fetchPolicy: 'cache-and-network', pollInterval: 15000 })
+  const { loading: ledgerLoading, data: { holofuelLedger: { balance: holofuelBalance } = {} } = {} } = useQuery(HolofuelLedgerQuery, { fetchPolicy: 'cache-and-network' })
   const { currentUser } = useCurrentUserContext()
 
   const [inboxView, setInboxView] = useState(VIEW.actionable)

--- a/src/holofuel/pages/Inbox/Inbox.js
+++ b/src/holofuel/pages/Inbox/Inbox.js
@@ -316,12 +316,10 @@ export function TransactionRow ({ transaction, setConfirmationModalProperties, i
   if (agent.id === null) return null
 
   if (!inProcess && actioned) {
-    console.log('actioned transaction ', transaction)
     hideTransaction()
   }
 
   const onTimeout = () => {
-    console.log(' -----========---- >> inProcess')
     setHighlightYellow(true)
     setIsDisabled(true)
     setTimeout(() => {

--- a/src/holofuel/pages/Inbox/Inbox.js
+++ b/src/holofuel/pages/Inbox/Inbox.js
@@ -243,7 +243,7 @@ export function Partition ({ dateLabel, transactions, userId, setConfirmationMod
   
   const transactionIsVisible = id => !hiddenTransactionIds.includes(id) || (hiddenTransactionIds.includes(id) && exemptTransactionIds.includes(id))
 
-  if (isEqual(hiddenTransactionIds, transactions.map(transaction => transaction.id))) return null
+  if (isEqual(hiddenTransactionIds, transactions.map(transaction => transaction.id)) && isEmpty(transactions.filter(transaction => exemptTransactionIds.includes(transaction.id)))) return null
 
   return <React.Fragment>
     <PageDivider title={dateLabel} />

--- a/src/holofuel/pages/Inbox/Inbox.js
+++ b/src/holofuel/pages/Inbox/Inbox.js
@@ -82,8 +82,8 @@ function useCounterparty (agentId) {
 }
 
 function useUpdatedTransactionLists () {
-  const { loading: allActionableLoading, data: { holofuelActionableTransactions = [] } = {} } = useQuery(HolofuelActionableTransactionsQuery, { fetchPolicy: 'cache-and-network', pollInterval: 15000 })
-  const { loading: allRecentLoading, data: { holofuelNonPendingTransactions = [] } = {} } = useQuery(HolofuelNonPendingTransactionsQuery, { fetchPolicy: 'cache-and-network', pollInterval: 15000 })
+  const { loading: allActionableLoading, data: { holofuelActionableTransactions = [] } = {} } = useQuery(HolofuelActionableTransactionsQuery, { fetchPolicy: 'cache-and-network' })
+  const { loading: allRecentLoading, data: { holofuelNonPendingTransactions = [] } = {} } = useQuery(HolofuelNonPendingTransactionsQuery, { fetchPolicy: 'cache-and-network' })
 
   const updatedDisplayableActionable = holofuelActionableTransactions.filter(shouldShowTransactionInInbox)
 

--- a/src/holofuel/pages/Inbox/Inbox.js
+++ b/src/holofuel/pages/Inbox/Inbox.js
@@ -128,7 +128,7 @@ export default function Inbox ({ history: { push } }) {
   }
   if (!isEmpty(userMessage)) {
     newMessage(userMessage, 5000)
-  } 
+  }
 
   const defaultConfirmationModalProperties = {
     shouldDisplay: false,
@@ -240,7 +240,7 @@ export function Partition ({ dateLabel, transactions, userId, setConfirmationMod
       setExemptTransactionIds(remove(id, exemptTransactionIds))
     }
   }
-  
+
   const transactionIsVisible = id => !hiddenTransactionIds.includes(id) || (hiddenTransactionIds.includes(id) && exemptTransactionIds.includes(id))
 
   if (isEqual(hiddenTransactionIds, transactions.map(transaction => transaction.id)) && isEmpty(transactions.filter(transaction => exemptTransactionIds.includes(transaction.id)))) return null
@@ -462,7 +462,7 @@ function ActionOptions ({ isOffer, isRequest, transaction, showAcceptModal, show
   </aside>
 }
 
-function AmountCell ({ amount, isRequest, isOffer, isActionable, isOutgoing, isCanceled, isDeclined }) {  
+function AmountCell ({ amount, isRequest, isOffer, isActionable, isOutgoing, isCanceled, isDeclined }) {
   let amountDisplay
   if (isActionable) {
     amountDisplay = isRequest ? `(${presentTruncatedAmount(presentHolofuelAmount(amount), 15)})` : presentTruncatedAmount(presentHolofuelAmount(amount), 15)

--- a/src/holofuel/pages/Inbox/Inbox.js
+++ b/src/holofuel/pages/Inbox/Inbox.js
@@ -230,20 +230,18 @@ export default function Inbox ({ history: { push } }) {
 
 export function Partition ({ dateLabel, transactions, userId, setConfirmationModalProperties, isActionable, openDrawerId, setOpenDrawerId, areActionsPaused, setAreActionsPaused }) {
   const [hiddenTransactionIds, setHiddenTransactionIds] = useState([])
-  const [exemptTransactionIds, setExemptTransactionIds] = useState([])
 
-  const hideTransactionWithId = id => setHiddenTransactionIds(hiddenTransactionIds.concat([id]))
-  const manageExemptTransactionWithId = (id, shouldExempt) => {
-    if (shouldExempt) {
-      setExemptTransactionIds(exemptTransactionIds.concat([id]))
+  const manageHideTransactionWithId = (id, shouldHide) => {
+    if (shouldHide) {
+      setHiddenTransactionIds(hiddenTransactionIds.concat([id]))
     } else {
-      setExemptTransactionIds(remove(id, exemptTransactionIds))
+      setHiddenTransactionIds(remove(id, hiddenTransactionIds))
     }
   }
 
-  const transactionIsVisible = id => !hiddenTransactionIds.includes(id) || (hiddenTransactionIds.includes(id) && exemptTransactionIds.includes(id))
+  const transactionIsVisible = id => !hiddenTransactionIds.includes(id)
 
-  if (isEqual(hiddenTransactionIds, transactions.map(transaction => transaction.id)) && isEmpty(transactions.filter(transaction => exemptTransactionIds.includes(transaction.id)))) return null
+  if (isEqual(hiddenTransactionIds, transactions.map(transaction => transaction.id))) return null
 
   return <React.Fragment>
     <PageDivider title={dateLabel} />
@@ -253,8 +251,7 @@ export function Partition ({ dateLabel, transactions, userId, setConfirmationMod
         setConfirmationModalProperties={setConfirmationModalProperties}
         isActionable={isActionable}
         userId={userId}
-        hideTransaction={() => hideTransactionWithId(transaction.id)}
-        exemptTransaction={shouldExempt => manageExemptTransactionWithId(transaction.id, shouldExempt)}
+        hideTransaction={shouldHide => manageHideTransactionWithId(transaction.id, shouldHide)}
         openDrawerId={openDrawerId}
         setOpenDrawerId={setOpenDrawerId}
         areActionsPaused={areActionsPaused}
@@ -265,7 +262,7 @@ export function Partition ({ dateLabel, transactions, userId, setConfirmationMod
   </React.Fragment>
 }
 
-export function TransactionRow ({ transaction, setConfirmationModalProperties, isActionable, userId, hideTransaction, exemptTransaction, areActionsPaused, setAreActionsPaused, openDrawerId, setOpenDrawerId }) {
+export function TransactionRow ({ transaction, setConfirmationModalProperties, isActionable, userId, hideTransaction, areActionsPaused, setAreActionsPaused, openDrawerId, setOpenDrawerId }) {
   const { id, counterparty, amount, type, status, direction, notes, canceledBy, isPayingARequest, inProcess, actioned } = transaction
 
   const isDrawerOpen = id === openDrawerId
@@ -315,8 +312,8 @@ export function TransactionRow ({ transaction, setConfirmationModalProperties, i
 
   if (agent.id === null) return null
 
-  if (!inProcess && actioned) {
-    hideTransaction()
+  if (!inProcess && !highlightGreen && actioned) {
+    hideTransaction(true)
   }
 
   const onTimeout = () => {
@@ -336,11 +333,11 @@ export function TransactionRow ({ transaction, setConfirmationModalProperties, i
     setHighlightYellow(false)
     setHighlightGreen(true)
     setIsDisabled(true)
-    exemptTransaction(true)
+    hideTransaction(false)
     setTimeout(() => {
       setHighlightGreen(false)
       setIsDisplayingInProcess(false)
-      exemptTransaction(false)
+      hideTransaction(true)
     }, 5000)
   }
 
@@ -348,10 +345,10 @@ export function TransactionRow ({ transaction, setConfirmationModalProperties, i
     setHighlightYellow(false)
     setHighlightRed(true)
     setIsDisabled(true)
-    exemptTransaction(true)
+    hideTransaction(false)
     setTimeout(() => {
       setHighlightRed(false)
-      exemptTransaction(false)
+      hideTransaction(true)
     }, 5000)
   }
 

--- a/src/holofuel/pages/Inbox/Inbox.js
+++ b/src/holofuel/pages/Inbox/Inbox.js
@@ -442,7 +442,7 @@ function ActionOptions ({ isOffer, isRequest, transaction, showAcceptModal, show
   </aside>
 }
 
-function AmountCell ({ amount, isRequest, isOffer, isActionable, isOutgoing, isCanceled, isDeclined }) {  
+function AmountCell ({ amount, isRequest, isOffer, isActionable, isOutgoing, isCanceled, isDeclined }) {
   let amountDisplay
   if (isActionable) {
     amountDisplay = isRequest ? `(${presentTruncatedAmount(presentHolofuelAmount(amount), 15)})` : presentTruncatedAmount(presentHolofuelAmount(amount), 15)

--- a/src/holofuel/pages/Inbox/Inbox.module.css
+++ b/src/holofuel/pages/Inbox/Inbox.module.css
@@ -206,8 +206,8 @@
   background-color: #FCE3E8;
 }
 
-.highlightNeutral {
-  background-color: #e4e6e9;
+.highlightYellow {
+  background-color: #f1d37a;
 }
 
 .inProcess {

--- a/src/holofuel/pages/TransactionHistory/TransactionHistory.js
+++ b/src/holofuel/pages/TransactionHistory/TransactionHistory.js
@@ -25,8 +25,8 @@ function usePollCompletedTransactions ({ since }) {
 const FILTER_TYPES = ['all', 'withdrawals', 'deposits', 'pending']
 
 export default function TransactionsHistory ({ history: { push } }) {
-  const { loading: ledgerLoading, data: { holofuelLedger: { balance: holofuelBalance } = {} } = {} } = useQuery(HolofuelLedgerQuery, { fetchPolicy: 'cache-and-network', pollInterval: 15000 })
-  const { loading: loadingPendingTransactions, data: { holofuelWaitingTransactions = [] } = {} } = useQuery(HolofuelWaitingTransactionsQuery, { fetchPolicy: 'cache-and-network', pollInterval: 15000 })
+  const { loading: ledgerLoading, data: { holofuelLedger: { balance: holofuelBalance } = {} } = {} } = useQuery(HolofuelLedgerQuery, { fetchPolicy: 'cache-and-network' })
+  const { loading: loadingPendingTransactions, data: { holofuelWaitingTransactions = [] } = {} } = useQuery(HolofuelWaitingTransactionsQuery, { fetchPolicy: 'cache-and-network' })
   const { loading: loadingCompletedTransactions, data: { holofuelCompletedTransactions = [] } = {} } = useQuery(HolofuelCompletedTransactionsQuery, { fetchPolicy: 'cache-and-network' })
 
   const since = !isEmpty(holofuelCompletedTransactions) ? holofuelCompletedTransactions[0].timestamp : ''


### PR DESCRIPTION
### Updates : 
 - ensures all non-inProcess actioned transactions remain hidden until the next successful fetch of list_pending
 - ensures all inProcess actioned transactions still render
 - coordinates the inProcess render timing to display the wording and highlighting at the same time (D-01069)
 - updates the inProcess highlighting to yellow
 - updates successful processing of inProcess transactions to render the green transaction highlight upon success

> For tickets : D-01069 & D-01072

## To Test
 - Spin up two Agents and sim2h
 - Create 1 offer from Agent 1 to Agent 2
 - Create 1 request from Agent 1 to Agent 2
 - Have Agent 2 accept the offer
 - Notice that inProcess rendering (updated highlight color and coordinated timing)
 - Notice that once the inProcess transaction successfully completed acceptance, the success message appears and the transaction is highlighted in green prior to disappearing
 - Have Agent 2 accept the request
 - Wait until the transaction is successful - notice that it never returns to inbox after clicking accept