### PR TITLE
hpos-env update; bump version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hp-admin",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hp-admin",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "private": true,
   "scripts": {
     "start": "REACT_APP_VERSION=$npm_package_version npm run start:mock",

--- a/src/holochainClient.js
+++ b/src/holochainClient.js
@@ -121,7 +121,7 @@ export let wsConnection = holochainClient
     ? true
     : process.env.REACT_APP_HOLOFUEL_APP === 'true'
       ? false
-      : process.env.NODE_ENV === 'development'
+      : true
 
 async function initHolochainClient () {
   isInitiatingHcConnection = true


### PR DESCRIPTION
### Updates: 
  - Update all HPOS env to start default ws connection to true

## To Test:
> Development
 - run `npm run start:live`
 - notice that at the sign-in page you are able to sign in, without and error signaling no connection
 - sign in and notice that the lack of connection to the conductor is caught after 3 unsuccessful zome calls, which redirects you to the login page, and signals the failure to connect flash message
 - spin up conductor-1
 - notice you the message disappear and the ability to sign in return
 - sign in and notice all zome calls pass through as expected
  
> Production
  - Enter into hpos-shell, ping the server and open your browser to your agent url, when you arrive you should see that the connection does not default to false, and as long as there is not a network error or server error (500s) then, you don't receive a notice signaling failure to connect to the conductor.