### PR TITLE
B-01900 - ui feedback edits

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hp-admin",
-  "version": "0.12.6",
+  "version": "0.12.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hp-admin",
-  "version": "0.12.6",
+  "version": "0.12.7",
   "private": true,
   "scripts": {
     "start": "REACT_APP_VERSION=$npm_package_version npm run start:mock",

--- a/src/components/AlphaFlag/AlphaFlag.module.css
+++ b/src/components/AlphaFlag/AlphaFlag.module.css
@@ -3,7 +3,7 @@
 }
 
 .flag {
-  background-color: var(--color-havelock-blue);
+  background-color: #6D5AAD;
   font-family: 'Circular';
   font-style: normal;
   font-weight: bold;
@@ -33,7 +33,7 @@
   border-top: 16px solid transparent;
   border-bottom: 16px solid transparent;
   
-  border-right: 16px solid var(--color-havelock-blue);
+  border-right: 16px solid #6D5AAD;
 }
 
 .right-arrow {
@@ -42,5 +42,5 @@
   border-top: 16px solid transparent;
   border-bottom: 16px solid transparent;
   
-  border-left: 16px solid var(--color-havelock-blue);
+  border-left: 16px solid #6D5AAD;
 }

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -1,21 +1,20 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
-import HashAvatar from 'components/HashAvatar'
 import './Header.module.css'
-import useCurrentUserContext from 'contexts/useCurrentUserContext'
+import BackIcon from 'components/icons/BackIcon'
 import GearIcon from 'components/icons/GearIcon'
+import { HP_ADMIN_SETTINGS } from 'utils/urls'
 
-export default function Header ({ title, hamburgerClick }) {
-  const { currentUser } = useCurrentUserContext()
-  const leftNav = hamburgerClick && <Link to='/admin/settings' styleName='settings-link'>
-    <GearIcon styleName='gear-icon' />
-  </Link>
-
+export default function Header ({ title }) {
   return <div styleName='header'>
-    <div styleName='left-nav'>{leftNav}</div>
-    <h1 styleName='title'>{title}</h1>
     <Link to='/admin/dashboard' styleName='avatar-link' data-testid='avatar-link'>
-      <HashAvatar seed={currentUser.hostPubKey} size={32} />
+      {window.location.pathname === HP_ADMIN_SETTINGS && <BackIcon styleName='back-icon' />}
     </Link>
+    <h1 styleName='title'>{title}</h1>
+    <div styleName='left-nav'>
+      <Link to='/admin/settings' styleName='settings-link'>
+        <GearIcon styleName='gear-icon' />
+      </Link>
+    </div>
   </div>
 }

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -1,21 +1,20 @@
 import React from 'react'
-import Button from 'components/Button'
+import { Link } from 'react-router-dom'
 import HashAvatar from 'components/HashAvatar'
 import './Header.module.css'
-import { Link } from 'react-router-dom'
 import useCurrentUserContext from 'contexts/useCurrentUserContext'
-import MenuIcon from 'components/icons/MenuIcon'
+import GearIcon from 'components/icons/GearIcon'
 
 export default function Header ({ title, hamburgerClick }) {
   const { currentUser } = useCurrentUserContext()
-  const leftNav = hamburgerClick && <Button onClick={hamburgerClick} styleName='menu-button' dataTestId='menu-button'>
-    <MenuIcon styleName='menu-icon' />
-  </Button>
+  const leftNav = hamburgerClick && <Link to='/admin/settings' styleName='settings-link'>
+    <GearIcon styleName='gear-icon' />
+  </Link>
 
   return <div styleName='header'>
     <div styleName='left-nav'>{leftNav}</div>
     <h1 styleName='title'>{title}</h1>
-    <Link to='/admin/settings' styleName='avatar-link' data-testid='avatar-link'>
+    <Link to='/admin/dashboard' styleName='avatar-link' data-testid='avatar-link'>
       <HashAvatar seed={currentUser.hostPubKey} size={32} />
     </Link>
   </div>

--- a/src/components/Header/Header.module.css
+++ b/src/components/Header/Header.module.css
@@ -49,6 +49,7 @@
   color: var(--color-cape-cod);
 }
 
+.back-icon,
 .gear-icon {
   width: 20px;
   height: 20px;

--- a/src/components/Header/Header.module.css
+++ b/src/components/Header/Header.module.css
@@ -36,3 +36,22 @@
   height: 32px;
   margin-right: 5px;
 }
+
+.settings-link {
+  font-family: 'Circular';
+  font-size: 14px;
+  line-height: 16px;
+  color: var(--color-cape-cod);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-decoration: none;
+  color: var(--color-cape-cod);
+}
+
+.gear-icon {
+  width: 20px;
+  height: 20px;
+  margin-top: 2px;
+  margin-right: 2px;
+}

--- a/src/components/SideMenu/SideMenu.module.css
+++ b/src/components/SideMenu/SideMenu.module.css
@@ -28,7 +28,7 @@
 .drawer--open .container {
   transform: translateX(100%);
   pointer-events: initial;
-  overflow-y: scroll;
+  /* overflow-y: scroll; */
 }
 
 .drawer-overlay {

--- a/src/components/layout/PrimaryLayout/PrimaryLayout.js
+++ b/src/components/layout/PrimaryLayout/PrimaryLayout.js
@@ -45,7 +45,7 @@ export function PrimaryLayout ({
 
   useEffect(() => {
     setIsInsideApp(window.location.pathname !== ROOT && window.location.pathname !== HP_ADMIN_LOGIN)
-    
+
     if (!isConnected.hpos) {
       // reroute to login on network/hpos connection error
       if (isInsideApp) {

--- a/src/components/layout/PrimaryLayout/PrimaryLayout.js
+++ b/src/components/layout/PrimaryLayout/PrimaryLayout.js
@@ -21,8 +21,7 @@ import 'global-styles/index.css'
 export function PrimaryLayout ({
   children,
   headerProps = {},
-  showHeader = true,
-  showSideMenu = true,
+  showHeader = true
 }) {
   const [isInsideApp, setIsInsideApp] = useState(true)
 
@@ -47,7 +46,6 @@ export function PrimaryLayout ({
 
   useEffect(() => {
     setIsInsideApp(window.location.pathname !== ROOT && window.location.pathname !== HP_ADMIN_LOGIN)
-    console.log(isInsideApp)
     
     if (!isConnected.hpos) {
       // reroute to login on network/hpos connection error
@@ -102,14 +100,11 @@ export function PrimaryLayout ({
     setIsInsideApp])
 
   const isWide = useContext(ScreenWidthContext)
-  const [isMenuOpen, setMenuOpen] = useState(false)
-  const hamburgerClick = () => setMenuOpen(!isMenuOpen)
 
   return <div styleName='styles.primary-layout'>
     <div styleName={cx({ 'styles.wide': isWide }, { 'styles.narrow': !isWide })}>
       {showHeader && <Header
         {...headerProps}
-        hamburgerClick={showSideMenu && hamburgerClick}
         settings={isConnected.hpos ? settings : {}} />}
 
       <div styleName='styles.content'>
@@ -132,7 +127,6 @@ export function PrimaryLayout ({
                 Alpha Testnet.
               </a>
             </p>
-  {/* 
             <ul styleName='styles.footer-list-2'>
               <li styleName='styles.footer-list-item-2'>
                 <a href='https://forum.holo.host' target='_blank' rel='noopener noreferrer' styleName='styles.footer-link-2'>Help</a>
@@ -140,17 +134,8 @@ export function PrimaryLayout ({
               <li styleName='styles.footer-list-item-2'>
                 <a href='http://holo.host/alpha-terms' target='_blank' rel='noopener noreferrer' styleName='styles.footer-link-2'>View Terms of Service</a>
               </li>
-            </ul> */}
+            </ul>
           </div>
-
-          <ul styleName='styles.footer-list'>
-            <li styleName='styles.footer-list-item'>
-              <a href='https://forum.holo.host' target='_blank' rel='noopener noreferrer' styleName='styles.footer-link'>Help</a>
-            </li>
-            <li styleName='styles.footer-list-item'>
-              <a href='http://holo.host/alpha-terms' target='_blank' rel='noopener noreferrer' styleName='styles.footer-link'>View Terms of Service</a>
-            </li>
-          </ul>
         </footer>
       </div>
     </div>}

--- a/src/components/layout/PrimaryLayout/PrimaryLayout.js
+++ b/src/components/layout/PrimaryLayout/PrimaryLayout.js
@@ -5,7 +5,6 @@ import { useHistory } from 'react-router-dom'
 import { useQuery } from '@apollo/react-hooks'
 import ScreenWidthContext from 'contexts/screenWidth'
 import FlashMessage from 'components/FlashMessage'
-import SideMenu from 'components/SideMenu'
 import Header from 'components/Header'
 import AlphaFlag from 'components/AlphaFlag'
 import HposSettingsQuery from 'graphql/HposSettingsQuery.gql'
@@ -14,6 +13,7 @@ import useFlashMessageContext from 'contexts/useFlashMessageContext'
 import useCurrentUserContext from 'contexts/useCurrentUserContext'
 import { useInterval } from 'utils'
 import { wsConnection } from 'holochainClient'
+import { ROOT, HP_ADMIN_LOGIN } from 'utils/urls'
 import styles from './PrimaryLayout.module.css' // eslint-disable-line no-unused-vars
 import 'global-styles/colors.css'
 import 'global-styles/index.css'
@@ -23,8 +23,9 @@ export function PrimaryLayout ({
   headerProps = {},
   showHeader = true,
   showSideMenu = true,
-  showAlphaFlag = true
 }) {
+  const [isInsideApp, setIsInsideApp] = useState(true)
+
   const [isHposConnectionAlive, setIsHposConnectionAlive] = useState(true)
   const { setIsConnected, isConnected } = useConnectionContext()
   const { setCurrentUser } = useCurrentUserContext()
@@ -39,17 +40,18 @@ export function PrimaryLayout ({
   const isFreshHpAdminRender = useRef(true)
 
   useInterval(() => {
-    if (window.location.pathname !== '/' || window.location.pathname !== '/admin/login') {
+    if (isInsideApp) {
       setIsConnected({ hpos: isHposConnectionAlive, holochain: wsConnection })
     }
   }, 5000)
 
   useEffect(() => {
-    console.log('HPOS connection : ', isConnected)
-
+    setIsInsideApp(window.location.pathname !== ROOT && window.location.pathname !== HP_ADMIN_LOGIN)
+    console.log(isInsideApp)
+    
     if (!isConnected.hpos) {
       // reroute to login on network/hpos connection error
-      if (window.location.pathname !== '/' && window.location.pathname !== '/admin/login') {
+      if (isInsideApp) {
         push('/admin/login')
       }
       newMessage('Connecting to your Holoport...', 0)
@@ -67,7 +69,7 @@ export function PrimaryLayout ({
       // if inside happ, check for connection to holochain
       if (!isFreshHpAdminRender.current && isConnected.hpos && !isConnected.holochain) {
         // reroute to login on conductor connection error as it signals emerging hpos connetion failure
-        if (window.location.pathname !== '/' && window.location.pathname !== '/admin/login') {
+        if (isInsideApp) {
           push('/admin/login')
         }
       } else {
@@ -95,27 +97,63 @@ export function PrimaryLayout ({
     settings.hostPubKey,
     settings.hostName,
     setIsConnected,
-    isHposConnectionAlive])
+    isHposConnectionAlive,
+    isInsideApp,
+    setIsInsideApp])
 
   const isWide = useContext(ScreenWidthContext)
   const [isMenuOpen, setMenuOpen] = useState(false)
   const hamburgerClick = () => setMenuOpen(!isMenuOpen)
-  const handleMenuClose = () => setMenuOpen(false)
 
-  return <div styleName={cx('styles.primary-layout', { 'styles.wide': isWide }, { 'styles.narrow': !isWide })}>
-    {showHeader && <Header
-      {...headerProps}
-      hamburgerClick={showSideMenu && hamburgerClick}
-      settings={isConnected.hpos ? settings : {}} />}
-    <SideMenu
-      isOpen={isMenuOpen}
-      handleClose={handleMenuClose}
-      settings={isConnected.hpos ? settings : {}} />
-    {showAlphaFlag && <AlphaFlag styleName='styles.alpha-flag' />}
-    <div styleName='styles.content'>
-      <FlashMessage />
-      {children}
+  return <div styleName='styles.primary-layout'>
+    <div styleName={cx({ 'styles.wide': isWide }, { 'styles.narrow': !isWide })}>
+      {showHeader && <Header
+        {...headerProps}
+        hamburgerClick={showSideMenu && hamburgerClick}
+        settings={isConnected.hpos ? settings : {}} />}
+
+      <div styleName='styles.content'>
+        <FlashMessage />
+        {children}
+      </div>
     </div>
+
+    {isInsideApp && <div styleName='styles.wrapper'>
+      <div styleName='styles.container'>
+        <footer styleName='styles.footer'>
+          <div styleName='styles.alpha-info'>
+            <AlphaFlag variant='right' styleName='styles.alpha-flag' />
+            <p>
+              HP Admin is in Alpha testing.
+            </p>
+            <p>
+              Learn more about out our&nbsp;
+              <a href='https://holo.host/holo-testnet' target='_blank' rel='noopener noreferrer' styleName='styles.alpha-link'>
+                Alpha Testnet.
+              </a>
+            </p>
+  {/* 
+            <ul styleName='styles.footer-list-2'>
+              <li styleName='styles.footer-list-item-2'>
+                <a href='https://forum.holo.host' target='_blank' rel='noopener noreferrer' styleName='styles.footer-link-2'>Help</a>
+              </li>
+              <li styleName='styles.footer-list-item-2'>
+                <a href='http://holo.host/alpha-terms' target='_blank' rel='noopener noreferrer' styleName='styles.footer-link-2'>View Terms of Service</a>
+              </li>
+            </ul> */}
+          </div>
+
+          <ul styleName='styles.footer-list'>
+            <li styleName='styles.footer-list-item'>
+              <a href='https://forum.holo.host' target='_blank' rel='noopener noreferrer' styleName='styles.footer-link'>Help</a>
+            </li>
+            <li styleName='styles.footer-list-item'>
+              <a href='http://holo.host/alpha-terms' target='_blank' rel='noopener noreferrer' styleName='styles.footer-link'>View Terms of Service</a>
+            </li>
+          </ul>
+        </footer>
+      </div>
+    </div>}
   </div>
 }
 

--- a/src/components/layout/PrimaryLayout/PrimaryLayout.js
+++ b/src/components/layout/PrimaryLayout/PrimaryLayout.js
@@ -24,7 +24,6 @@ export function PrimaryLayout ({
   showHeader = true
 }) {
   const [isInsideApp, setIsInsideApp] = useState(true)
-
   const [isHposConnectionAlive, setIsHposConnectionAlive] = useState(true)
   const { setIsConnected, isConnected } = useConnectionContext()
   const { setCurrentUser } = useCurrentUserContext()

--- a/src/components/layout/PrimaryLayout/PrimaryLayout.js
+++ b/src/components/layout/PrimaryLayout/PrimaryLayout.js
@@ -126,12 +126,12 @@ export function PrimaryLayout ({
                 Alpha Testnet.
               </a>
             </p>
-            <ul styleName='styles.footer-list-2'>
-              <li styleName='styles.footer-list-item-2'>
-                <a href='https://forum.holo.host' target='_blank' rel='noopener noreferrer' styleName='styles.footer-link-2'>Help</a>
+            <ul styleName='styles.footer-list'>
+              <li styleName='styles.footer-list-item'>
+                <a href='https://forum.holo.host' target='_blank' rel='noopener noreferrer' styleName='styles.footer-link'>Help</a>
               </li>
-              <li styleName='styles.footer-list-item-2'>
-                <a href='http://holo.host/alpha-terms' target='_blank' rel='noopener noreferrer' styleName='styles.footer-link-2'>View Terms of Service</a>
+              <li styleName='styles.footer-list-item'>
+                <a href='http://holo.host/alpha-terms' target='_blank' rel='noopener noreferrer' styleName='styles.footer-link'>View Terms of Service</a>
               </li>
             </ul>
           </div>

--- a/src/components/layout/PrimaryLayout/PrimaryLayout.module.css
+++ b/src/components/layout/PrimaryLayout/PrimaryLayout.module.css
@@ -35,6 +35,92 @@
   cursor: pointer;
 }
 
-.side-menu {
+/* .side-menu {
   padding-right: 10px;
+} */
+
+
+/* Footer */
+
+.wrapper {
+  box-sizing: border-box;
+  margin-top: auto;
+  padding: 0px 24px;
+  position: sticky;
+  bottom: 0;
+}
+
+.container {
+  box-sizing: border-box;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  background-color: var(--color-alabaster-light);
+  pointer-events: none;
+}
+
+.footer {
+  flex-shrink: 0;
+  justify-self: flex-end;
+  margin: 0px 10px;
+}
+
+.footer-list {
+  padding: 0;
+  list-style-type: none;
+}
+
+.footer-list-item {
+  padding: 4px 0px;
+}
+
+.footer-link {
+  text-decoration: none;
+  font-size: 14px;
+  line-height: 16px;
+  color: var(--color-caribbean-green)
+}
+
+.footer-list-2 {
+  padding: 0;
+  list-style-type: none;
+  display: flex;
+  flex-direction: column;
+  /* text-align: right; */
+}
+
+.footer-list-item-2 {
+  padding: 4px 0px;
+}
+
+.footer-link-2 {
+  text-decoration: none;
+  font-size: 14px;
+  line-height: 16px;
+  color: var(--color-rhino-35)
+}
+
+/* Alpha Info */
+
+.alpha-info {
+  position: relative;
+  margin: 0 -32px 0px -32px;
+  padding: 30px 12px;
+  font-family: 'Circular';
+  font-size: 14px;
+  line-height: 16px;
+  color: var(--color-rhino);
+  background-color: var(--color-iceberg);
+  box-shadow: 1px -1.5px 14px rgba(163, 160, 160, 0.5);
+}
+
+.alpha-flag {
+  position: absolute;
+  top: -16px;
+  left: 0px;
+}
+
+.alpha-link {
+  color: var(--color-rhino);
 }

--- a/src/components/layout/PrimaryLayout/PrimaryLayout.module.css
+++ b/src/components/layout/PrimaryLayout/PrimaryLayout.module.css
@@ -35,10 +35,6 @@
   cursor: pointer;
 }
 
-/* .side-menu {
-  padding-right: 10px;
-} */
-
 
 /* Footer */
 
@@ -46,18 +42,18 @@
   box-sizing: border-box;
   margin-top: auto;
   padding: 0px 24px;
+  position: -webkit-sticky;
   position: sticky;
-  bottom: 0;
+  bottom: 2rem;
 }
 
 .container {
   box-sizing: border-box;
-  width: 100%;
+  width: 26%;
   height: 100%;
   display: flex;
   flex-direction: column;
   background-color: var(--color-alabaster-light);
-  pointer-events: none;
 }
 
 .footer {
@@ -83,6 +79,7 @@
 }
 
 .footer-list-2 {
+  margin: 0;
   padding: 0;
   list-style-type: none;
   display: flex;
@@ -106,7 +103,7 @@
 .alpha-info {
   position: relative;
   margin: 0 -32px 0px -32px;
-  padding: 30px 12px;
+  padding: 32px 10px 8px 10px;
   font-family: 'Circular';
   font-size: 14px;
   line-height: 16px;

--- a/src/components/layout/PrimaryLayout/PrimaryLayout.module.css
+++ b/src/components/layout/PrimaryLayout/PrimaryLayout.module.css
@@ -63,22 +63,6 @@
 }
 
 .footer-list {
-  padding: 0;
-  list-style-type: none;
-}
-
-.footer-list-item {
-  padding: 4px 0px;
-}
-
-.footer-link {
-  text-decoration: none;
-  font-size: 14px;
-  line-height: 16px;
-  color: var(--color-caribbean-green)
-}
-
-.footer-list-2 {
   margin: 0;
   padding: 0;
   list-style-type: none;
@@ -87,11 +71,11 @@
   /* text-align: right; */
 }
 
-.footer-list-item-2 {
+.footer-list-item {
   padding: 4px 0px;
 }
 
-.footer-link-2 {
+.footer-link {
   text-decoration: none;
   font-size: 14px;
   line-height: 16px;
@@ -108,7 +92,7 @@
   font-size: 14px;
   line-height: 16px;
   color: var(--color-rhino);
-  background-color: var(--color-iceberg);
+  background-color: #d2f2f5;
   box-shadow: 1px -1.5px 14px rgba(163, 160, 160, 0.5);
 }
 

--- a/src/holofuel/HFRouter.js
+++ b/src/holofuel/HFRouter.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import AuthRoute from 'components/AuthRoute'
 import { Route, Switch, Redirect } from 'react-router-dom'
-import Home from 'holofuel/pages/Home'
 import Inbox from 'holofuel/pages/Inbox'
 import TransactionHistory from 'holofuel/pages/TransactionHistory'
 import CreateOfferRequest from 'holofuel/pages/CreateOfferRequest'
@@ -18,8 +17,7 @@ function HFRoute (props) {
 
 export default function HFRouter () {
   return <Switch>
-    <HFRoute path='/holofuel/(|home)' exact component={Home} />
-    <HFRoute path='/holofuel/inbox' exact component={Inbox} />
+    <HFRoute path='/holofuel/(|inbox)' exact component={Inbox} />
     <HFRoute path='/holofuel/history' exact component={TransactionHistory} />
     <HFRoute path='/holofuel/offer-request' exact component={CreateOfferRequest} />
     <HFRoute path='/holofuel/profile' exact component={Profile} />

--- a/src/holofuel/components/CopyToClipboard/CopyToClipboard.js
+++ b/src/holofuel/components/CopyToClipboard/CopyToClipboard.js
@@ -13,7 +13,7 @@ export default function CopyToClipboard ({
 
   const handleCopyItem = async () => {
     const wasCopied = await copy(copyContent)
-    if (wasCopied === true) newMessage(messageText, 5000)
+    if (wasCopied === true) newMessage(messageText,  0)
   }
 
   return <div onClick={handleCopyItem} styleName='copy-item'>

--- a/src/holofuel/components/CopyToClipboard/CopyToClipboard.js
+++ b/src/holofuel/components/CopyToClipboard/CopyToClipboard.js
@@ -13,7 +13,7 @@ export default function CopyToClipboard ({
 
   const handleCopyItem = async () => {
     const wasCopied = await copy(copyContent)
-    if (wasCopied === true) newMessage(messageText,  5000)
+    if (wasCopied === true) newMessage(messageText, 5000)
   }
 
   return <div onClick={handleCopyItem} styleName='copy-item'>

--- a/src/holofuel/components/CopyToClipboard/CopyToClipboard.js
+++ b/src/holofuel/components/CopyToClipboard/CopyToClipboard.js
@@ -13,7 +13,7 @@ export default function CopyToClipboard ({
 
   const handleCopyItem = async () => {
     const wasCopied = await copy(copyContent)
-    if (wasCopied === true) newMessage(messageText,  0)
+    if (wasCopied === true) newMessage(messageText,  5000)
   }
 
   return <div onClick={handleCopyItem} styleName='copy-item'>

--- a/src/holofuel/components/FlashMessage/FlashMessage.js
+++ b/src/holofuel/components/FlashMessage/FlashMessage.js
@@ -1,9 +1,12 @@
-import React, { useCallback, useEffect } from 'react'
+import React, { useContext, useCallback, useEffect } from 'react'
 import { isEmpty } from 'lodash/fp'
+import cx from 'classnames'
+import ScreenWidthContext from 'holofuel/contexts/screenWidth'
 import useFlashMessageContext from 'holofuel/contexts/useFlashMessageContext'
 import './FlashMessage.module.css'
 
 export default function FlashMessage () {
+  const isWide = useContext(ScreenWidthContext)
   const { message, time, newMessage } = useFlashMessageContext()
   const clearMessage = useCallback(
     () => newMessage('', 0),
@@ -19,7 +22,7 @@ export default function FlashMessage () {
 
   if (isEmpty(message)) return null
 
-  return <div styleName='flash-message'>
+  return <div styleName={cx('flash-message', { 'desktop': isWide })}>
     <div styleName='flash-body'>{message}</div>
     <button styleName='close-button' onClick={clearMessage}>x</button>
   </div>

--- a/src/holofuel/components/FlashMessage/FlashMessage.js
+++ b/src/holofuel/components/FlashMessage/FlashMessage.js
@@ -22,8 +22,8 @@ export default function FlashMessage () {
 
   if (isEmpty(message)) return null
 
-  return <div styleName={cx('flash-message', { 'desktop': isWide })}>
-    <div styleName='flash-body'>{message}</div>
+  return <div styleName={cx('flash-message', { 'desktop-message': isWide })}>
+    <div styleName={cx('flash-body', { 'desktop-body': isWide })}>{message}</div>
     <button styleName='close-button' onClick={clearMessage}>x</button>
   </div>
 }

--- a/src/holofuel/components/FlashMessage/FlashMessage.module.css
+++ b/src/holofuel/components/FlashMessage/FlashMessage.module.css
@@ -14,13 +14,18 @@
   text-align: center;
 }
 
-.desktop {
+.desktop-message {
   width: calc(100vw - 308px);
 }
 
 .flash-body {
   display: flex;
   flex-flow: column;
+  margin: 0 auto;
+  margin-left: 30px;
+}
+
+.desktop-body {
   margin: 0 auto;
 }
 

--- a/src/holofuel/components/FlashMessage/FlashMessage.module.css
+++ b/src/holofuel/components/FlashMessage/FlashMessage.module.css
@@ -8,7 +8,6 @@
   padding: 10px;
   margin: 0 5px;
   align-items: center;
-  align-self: center;
   border-radius: 4px;
   z-index: 30;
   color: white;

--- a/src/holofuel/components/FlashMessage/FlashMessage.module.css
+++ b/src/holofuel/components/FlashMessage/FlashMessage.module.css
@@ -6,15 +6,17 @@
   background-color: var(--color-caribbean-green);
   opacity: 0.9;
   padding: 10px;
-  margin: 0 5px;
+  margin: 0 auto;
   align-items: center;
   border-radius: 4px;
   z-index: 30;
   color: white;
   text-align: center;
+  width: 98vw;
 }
 
 .desktop-message {
+  margin: 0 5px;
   width: calc(100vw - 308px);
 }
 

--- a/src/holofuel/components/FlashMessage/FlashMessage.module.css
+++ b/src/holofuel/components/FlashMessage/FlashMessage.module.css
@@ -14,11 +14,14 @@
   text-align: center;
 }
 
+.desktop {
+  width: calc(100vw - 308px);
+}
+
 .flash-body {
   display: flex;
   flex-flow: column;
   margin: 0 auto;
-  margin-left: 30px;
 }
 
 .message {

--- a/src/holofuel/components/Header/Header.js
+++ b/src/holofuel/components/Header/Header.js
@@ -6,7 +6,7 @@ import { withRouter } from 'react-router'
 import MenuIcon from 'components/icons/MenuIcon'
 import CopyAgentId from 'holofuel/components/CopyAgentId'
 
-export function Header ({ title, agent, agentLoading, avatarUrl, history: { push }, hamburgerClick = () => push('/dashboard'), inboxCount }) {
+export function Header ({ title, agent, agentLoading, history: { push }, hamburgerClick = () => push('/dashboard'), inboxCount }) {
   const leftNav = <Button onClick={hamburgerClick} styleName='menu-button' dataTestId='menu-button'>
     <MenuIcon styleName='menu-icon' color='#000000' />
     {inboxCount > 0 && <span styleName='nav-badge' data-testid='inboxCount-badge'>{inboxCount}</span>}
@@ -21,7 +21,7 @@ export function Header ({ title, agent, agentLoading, avatarUrl, history: { push
       </div>
       <div styleName='center-nav'>
         {title && <div styleName='page-header'>
-          <h1 styleName='page-title'>{title}</h1>
+          <h1 styleName='page-title'>Test Fuel - {title}</h1>
         </div>}
       </div>
       <div>

--- a/src/holofuel/components/Header/Header.js
+++ b/src/holofuel/components/Header/Header.js
@@ -7,7 +7,7 @@ import { withRouter } from 'react-router'
 import MenuIcon from 'components/icons/MenuIcon'
 import CopyAgentId from 'holofuel/components/CopyAgentId'
 
-export function Header ({ title, agent, agentLoading, history: { push }, hamburgerClick = () => push('/dashboard'), inboxCount, isWide}) {
+export function Header ({ agent, agentLoading, history: { push }, hamburgerClick = () => push('/dashboard'), inboxCount, isWide }) {
   const leftNav = <Button onClick={hamburgerClick} styleName='menu-button' dataTestId='menu-button'>
     <MenuIcon styleName='menu-icon' color='#000000' />
     {inboxCount > 0 && <span styleName='nav-badge' data-testid='inboxCount-badge'>{inboxCount}</span>}
@@ -21,7 +21,7 @@ export function Header ({ title, agent, agentLoading, history: { push }, hamburg
         {leftNav}
       </div>
       <div styleName='center-nav'>
-        <div styleName={cx('page-header', { 'desktop': isWide })}>
+        <div styleName={cx('page-header', { desktop: isWide })}>
           <h1 styleName='page-title'>Test Fuel</h1>
         </div>
       </div>

--- a/src/holofuel/components/Header/Header.js
+++ b/src/holofuel/components/Header/Header.js
@@ -20,9 +20,9 @@ export function Header ({ title, agent, agentLoading, history: { push }, hamburg
         {leftNav}
       </div>
       <div styleName='center-nav'>
-        {title && <div styleName='page-header'>
-          <h1 styleName='page-title'>{title}</h1>
-        </div>}
+        <div styleName='page-header'>
+          <h1 styleName='page-title'>Test Fuel</h1>
+        </div>
       </div>
       <div>
         <CopyAgentId agent={agent} isMe>

--- a/src/holofuel/components/Header/Header.js
+++ b/src/holofuel/components/Header/Header.js
@@ -21,7 +21,7 @@ export function Header ({ title, agent, agentLoading, history: { push }, hamburg
       </div>
       <div styleName='center-nav'>
         {title && <div styleName='page-header'>
-          <h1 styleName='page-title'>Test Fuel - {title}</h1>
+          <h1 styleName='page-title'>{title}</h1>
         </div>}
       </div>
       <div>

--- a/src/holofuel/components/Header/Header.js
+++ b/src/holofuel/components/Header/Header.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import cx from 'classnames'
 import Button from 'components/Button'
 import HashAvatar from 'components/HashAvatar'
 import './Header.module.css'
@@ -6,7 +7,7 @@ import { withRouter } from 'react-router'
 import MenuIcon from 'components/icons/MenuIcon'
 import CopyAgentId from 'holofuel/components/CopyAgentId'
 
-export function Header ({ title, agent, agentLoading, history: { push }, hamburgerClick = () => push('/dashboard'), inboxCount }) {
+export function Header ({ title, agent, agentLoading, history: { push }, hamburgerClick = () => push('/dashboard'), inboxCount, isWide}) {
   const leftNav = <Button onClick={hamburgerClick} styleName='menu-button' dataTestId='menu-button'>
     <MenuIcon styleName='menu-icon' color='#000000' />
     {inboxCount > 0 && <span styleName='nav-badge' data-testid='inboxCount-badge'>{inboxCount}</span>}
@@ -20,7 +21,7 @@ export function Header ({ title, agent, agentLoading, history: { push }, hamburg
         {leftNav}
       </div>
       <div styleName='center-nav'>
-        <div styleName='page-header'>
+        <div styleName={cx('page-header', { 'desktop': isWide })}>
           <h1 styleName='page-title'>Test Fuel</h1>
         </div>
       </div>

--- a/src/holofuel/components/Header/Header.module.css
+++ b/src/holofuel/components/Header/Header.module.css
@@ -97,3 +97,7 @@
 .empty-spacer {
   flex: 1;
 }
+
+.desktop {
+  margin-left: 260px;
+}

--- a/src/holofuel/components/SideMenu/SideMenu.js
+++ b/src/holofuel/components/SideMenu/SideMenu.js
@@ -3,7 +3,7 @@ import cx from 'classnames'
 import AlphaFlag from 'holofuel/components/AlphaFlag'
 import { Link, useLocation } from 'react-router-dom'
 import HashAvatar from 'components/HashAvatar'
-import { presentHolofuelAmount, presentAgentId } from 'utils'
+import { presentAgentId } from 'utils'
 import CopyAgentId from 'holofuel/components/CopyAgentId'
 import Button from 'components/UIButton'
 import Loading from 'components/Loading'
@@ -28,14 +28,13 @@ export default function SideMenu ({
   isLoadingRefetchCalls,
   refetchCalls
 }) {
-
-  let location = useLocation()
+  const location = useLocation()
   const [currentPath, setCurrentPath] = useState()
   useEffect(() => {
     setCurrentPath(location.pathname)
   }, [location])
 
-  return <aside styleName={cx('drawer', { 'drawer--open': isOpen }, { 'desktop' : isWide })}>
+  return <aside styleName={cx('drawer', { 'drawer--open': isOpen }, { desktop: isWide })}>
     <div styleName='container'>
       <header styleName='header'>
         <CopyAgentId agent={{ id: agent.id }} isMe>
@@ -54,12 +53,12 @@ export default function SideMenu ({
             </Link>
           </li>
           <li styleName={cx({ 'active-link': currentPath === '/holofuel/history/' || currentPath === '/holofuel/history' })}>
-            <Link to={HISTORY_PATH}  styleName='nav-link'>
+            <Link to={HISTORY_PATH} styleName='nav-link'>
               History
             </Link>
           </li>
           <li styleName={cx({ 'active-link': currentPath === '/holofuel/profile/' || currentPath === '/holofuel/profile' })}>
-            <Link to={PROFILE_PATH}  styleName='nav-link'>
+            <Link to={PROFILE_PATH} styleName='nav-link'>
               Profile
             </Link>
           </li>

--- a/src/holofuel/components/SideMenu/SideMenu.js
+++ b/src/holofuel/components/SideMenu/SideMenu.js
@@ -8,7 +8,6 @@ import CopyAgentId from 'holofuel/components/CopyAgentId'
 import Button from 'components/UIButton'
 import Loading from 'components/Loading'
 import {
-  HOME_PATH,
   INBOX_PATH,
   HISTORY_PATH,
   PROFILE_PATH
@@ -48,11 +47,6 @@ export default function SideMenu ({
       <nav styleName='nav'>
         <ul styleName='nav-list'>
           <li>
-            <Link to={HOME_PATH} styleName='nav-link'>
-              Home
-            </Link>
-          </li>
-          <li>
             <Link to={INBOX_PATH} styleName='nav-link'>
               Inbox <InboxBadge count={inboxCount} />
             </Link>
@@ -62,13 +56,13 @@ export default function SideMenu ({
               History
             </Link>
           </li>
-          <li>
-            <Link to={PROFILE_PATH} styleName='nav-link'>
+          <li styleName='last-list-item'>
+            <Link to={PROFILE_PATH} styleName='nav-link last-nav-link'>
               Profile
             </Link>
           </li>
           {process.env.REACT_APP_HOLOFUEL_APP !== 'true' && <li styleName='last-list-item'>
-            <Link to='/admin/' styleName='nav-link last-nav-link'>
+            <Link to='/admin/' styleName='nav-link admin-nav-link'>
               HP Admin
             </Link>
           </li>}

--- a/src/holofuel/components/SideMenu/SideMenu.js
+++ b/src/holofuel/components/SideMenu/SideMenu.js
@@ -34,8 +34,6 @@ export default function SideMenu ({
     setCurrentPath(location.pathname)
   }, [location])
 
-  const inboxPath = '/holofuel/inbox' || '/holofuel/' || '/holofuel'
-
   return <aside styleName={cx('drawer', { 'drawer--open': isOpen })}>
     <div styleName='container'>
       <header styleName='header'>

--- a/src/holofuel/components/SideMenu/SideMenu.js
+++ b/src/holofuel/components/SideMenu/SideMenu.js
@@ -34,6 +34,8 @@ export default function SideMenu ({
     setCurrentPath(location.pathname)
   }, [location])
 
+  const inboxPath = '/holofuel/inbox' || '/holofuel/' || '/holofuel'
+
   return <aside styleName={cx('drawer', { 'drawer--open': isOpen })}>
     <div styleName='container'>
       <header styleName='header'>
@@ -47,17 +49,17 @@ export default function SideMenu ({
 
       <nav styleName='nav'>
         <ul styleName='nav-list'>
-          <li styleName={cx({ 'active-link': currentPath === '/holofuel/inbox' })}>
+          <li styleName={cx({ 'active-link': currentPath === '/holofuel/inbox/' || currentPath === '/holofuel/inbox' || currentPath === '/holofuel/' || currentPath === '/holofuel' })}>
             <Link to={INBOX_PATH} styleName='nav-link'>
               Inbox <InboxBadge count={inboxCount} />
             </Link>
           </li>
-          <li styleName={cx({ 'active-link': currentPath === '/holofuel/history' })}>
+          <li styleName={cx({ 'active-link': currentPath === '/holofuel/history/' || currentPath === '/holofuel/history' })}>
             <Link to={HISTORY_PATH}  styleName='nav-link'>
               History
             </Link>
           </li>
-          <li styleName={cx({ 'active-link': currentPath === '/holofuel/profile' })}>
+          <li styleName={cx({ 'active-link': currentPath === '/holofuel/profile/' || currentPath === '/holofuel/profile' })}>
             <Link to={PROFILE_PATH}  styleName='nav-link'>
               Profile
             </Link>

--- a/src/holofuel/components/SideMenu/SideMenu.js
+++ b/src/holofuel/components/SideMenu/SideMenu.js
@@ -1,12 +1,14 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import cx from 'classnames'
 import AlphaFlag from 'holofuel/components/AlphaFlag'
-import { Link } from 'react-router-dom'
+import { Link, useLocation } from 'react-router-dom'
 import HashAvatar from 'components/HashAvatar'
 import { presentHolofuelAmount, presentAgentId } from 'utils'
 import CopyAgentId from 'holofuel/components/CopyAgentId'
 import Button from 'components/UIButton'
 import Loading from 'components/Loading'
+import BackIcon from 'components/icons/BackIcon'
+
 import {
   INBOX_PATH,
   HISTORY_PATH,
@@ -22,11 +24,16 @@ export default function SideMenu ({
   agent,
   agentLoading,
   inboxCount,
-  holofuelBalance,
-  ledgerLoading,
   isLoadingRefetchCalls,
   refetchCalls
 }) {
+
+  let location = useLocation()
+  const [currentPath, setCurrentPath] = useState()
+  useEffect(() => {
+    setCurrentPath(location.pathname)
+  }, [location])
+
   return <aside styleName={cx('drawer', { 'drawer--open': isOpen })}>
     <div styleName='container'>
       <header styleName='header'>
@@ -36,44 +43,40 @@ export default function SideMenu ({
         <h3 styleName='nickname'>
           {agent.nickname || (agentLoading && <>Loading...</>) || presentAgentId(agent.id)}
         </h3>
-
-        <h1 styleName='balance'><DisplayBalance
-          holofuelBalance={holofuelBalance}
-          ledgerLoading={ledgerLoading}
-        />
-        </h1>
       </header>
 
       <nav styleName='nav'>
         <ul styleName='nav-list'>
-          <li>
+          <li styleName={cx({ 'active-link': currentPath === '/holofuel/inbox' })}>
             <Link to={INBOX_PATH} styleName='nav-link'>
               Inbox <InboxBadge count={inboxCount} />
             </Link>
           </li>
-          <li>
-            <Link to={HISTORY_PATH} styleName='nav-link'>
+          <li styleName={cx({ 'active-link': currentPath === '/holofuel/history' })}>
+            <Link to={HISTORY_PATH}  styleName='nav-link'>
               History
             </Link>
           </li>
-          <li styleName='last-list-item'>
-            <Link to={PROFILE_PATH} styleName='nav-link last-nav-link'>
+          <li styleName={cx({ 'active-link': currentPath === '/holofuel/profile' })}>
+            <Link to={PROFILE_PATH}  styleName='nav-link'>
               Profile
             </Link>
           </li>
-          {process.env.REACT_APP_HOLOFUEL_APP !== 'true' && <li styleName='last-list-item'>
-            <Link to='/admin/' styleName='nav-link admin-nav-link'>
-              HP Admin
-            </Link>
-          </li>}
           <li>
-            <div styleName='loading-row'>
+            <div styleName='loading-row last-list-item'>
               <Button onClick={() => refetchCalls()} styleName={cx('refresh-button', { 'btn-loading': isLoadingRefetchCalls })} variant='green'>
                 Refresh
               </Button>
               {isLoadingRefetchCalls && <Loading styleName='refresh-loading' width={20} height={20} />}
             </div>
           </li>
+
+          {process.env.REACT_APP_HOLOFUEL_APP !== 'true' && <li styleName='last-list-item'>
+            <Link to='/admin/' styleName='nav-link admin-nav-link'>
+              <BackIcon styleName='back-icon' /> HP Admin
+            </Link>
+          </li>}
+
         </ul>
       </nav>
 

--- a/src/holofuel/components/SideMenu/SideMenu.js
+++ b/src/holofuel/components/SideMenu/SideMenu.js
@@ -19,6 +19,7 @@ import './SideMenu.module.css'
 
 export default function SideMenu ({
   isOpen,
+  isWide,
   handleClose,
   avatarUrl = '',
   agent,
@@ -34,7 +35,7 @@ export default function SideMenu ({
     setCurrentPath(location.pathname)
   }, [location])
 
-  return <aside styleName={cx('drawer', { 'drawer--open': isOpen })}>
+  return <aside styleName={cx('drawer', { 'drawer--open': isOpen }, { 'desktop' : isWide })}>
     <div styleName='container'>
       <header styleName='header'>
         <CopyAgentId agent={{ id: agent.id }} isMe>
@@ -106,13 +107,8 @@ export default function SideMenu ({
       </footer>
 
     </div>
-    <div styleName='drawer-overlay' onClick={handleClose} />
+    {!isWide && <div styleName='drawer-overlay' onClick={handleClose} />}
   </aside>
-}
-
-function DisplayBalance ({ ledgerLoading, holofuelBalance }) {
-  if (ledgerLoading || isNaN(holofuelBalance)) return <>-- TF</>
-  else return <>{presentHolofuelAmount(holofuelBalance)} TF</>
 }
 
 function InboxBadge ({ count = 0 }) {

--- a/src/holofuel/components/SideMenu/SideMenu.module.css
+++ b/src/holofuel/components/SideMenu/SideMenu.module.css
@@ -16,7 +16,7 @@
   height: 100%;
   display: flex;
   flex-direction: column;
-  padding: 32px 22px 20px;
+  padding: 14px 22px 20px;
   background-color: var(--color-alabaster-light);
   transform: translateX(-10%);
   transition: transform .3s ease;
@@ -154,7 +154,7 @@
 
 .alpha-info {
   position: relative;
-  margin: 0 -32px 60px -32px;
+  margin: 0 -32px 10px -32px;
   padding: 30px 12px;
   font-family: 'Circular';
   font-size: 14px;
@@ -179,6 +179,10 @@
 
 .last-nav-link {
   margin-bottom: 15px;
+}
+
+.admin-nav-link {
+  margin: 15px 0px
 }
 
 .btn-loading {

--- a/src/holofuel/components/SideMenu/SideMenu.module.css
+++ b/src/holofuel/components/SideMenu/SideMenu.module.css
@@ -97,6 +97,7 @@
   color: var(--color-cape-cod);
 }
 
+.back-icon,
 .gear-icon {
   width: 20px;
   height: 20px;
@@ -106,6 +107,12 @@
 
 .nav {
   color: #fff;
+}
+
+.active-link {
+  background-color: #CFF3EC;
+  padding: 0px 10px;
+  border-radius: 5px;
 }
 
 /* Header */

--- a/src/holofuel/components/SideMenu/SideMenu.module.css
+++ b/src/holofuel/components/SideMenu/SideMenu.module.css
@@ -28,7 +28,7 @@
 .drawer--open .container {
   transform: translateX(100%);
   pointer-events: initial;
-  overflow-y: scroll;
+  /* overflow-y: scroll; */
 }
 
 .refresh-button {
@@ -239,4 +239,8 @@
   font-size: 12px;
   text-align: center;
   margin-left: 10px;
+}
+
+.desktop {
+  flex: 0 1 280px;
 }

--- a/src/holofuel/components/layout/PrimaryLayout/PrimaryLayout.js
+++ b/src/holofuel/components/layout/PrimaryLayout/PrimaryLayout.js
@@ -107,7 +107,7 @@ function PrimaryLayout ({
   return <div styleName={cx('styles.primary-layout', { 'styles.wide': isWide }, { 'styles.narrow': !isWide })}>
     <Header {...headerProps} agent={currentUser} agentLoading={currentUserLoading} hamburgerClick={hamburgerClick} inboxCount={inboxCount} />
     <SideMenu
-      isOpen={isMenuOpen}
+      isOpen={isWide || isMenuOpen}
       handleClose={handleMenuClose}
       agent={currentUser}
       agentLoading={currentUserLoading}
@@ -118,7 +118,7 @@ function PrimaryLayout ({
       isLoadingRefetchCalls={isLoadingRefetchCalls}
       refetchCalls={refetchCalls} />
     {showAlphaFlag && <AlphaFlag styleName='styles.alpha-flag' />}
-    <div styleName={cx('styles.content')}>
+    <div styleName={cx('styles.content', { 'styles.desktop': isWide })}>
       <FlashMessage />
       {children}
     </div>

--- a/src/holofuel/components/layout/PrimaryLayout/PrimaryLayout.js
+++ b/src/holofuel/components/layout/PrimaryLayout/PrimaryLayout.js
@@ -105,7 +105,7 @@ function PrimaryLayout ({
   const isLoadingRefetchCalls = ledgerLoading || actionableTransactionsLoading || completedTransactionsLoading || nonPendingTransactionsLoading || waitingTransactionsLoading
 
   return <div styleName={cx('styles.primary-layout', { 'styles.wide': isWide }, { 'styles.narrow': !isWide })}>
-    <Header {...headerProps} agent={currentUser} agentLoading={currentUserLoading} hamburgerClick={hamburgerClick} inboxCount={inboxCount} />
+    <Header {...headerProps} agent={currentUser} agentLoading={currentUserLoading} hamburgerClick={hamburgerClick} inboxCount={inboxCount} isWide={isWide} />
     <SideMenu
       isOpen={isWide || isMenuOpen}
       handleClose={handleMenuClose}

--- a/src/holofuel/components/layout/PrimaryLayout/PrimaryLayout.js
+++ b/src/holofuel/components/layout/PrimaryLayout/PrimaryLayout.js
@@ -117,7 +117,7 @@ function PrimaryLayout ({
       isWide={isWide}
       isLoadingRefetchCalls={isLoadingRefetchCalls}
       refetchCalls={refetchCalls} />
-    {showAlphaFlag && <AlphaFlag styleName='styles.alpha-flag' />}
+    {(!isWide && showAlphaFlag) && <AlphaFlag styleName='styles.alpha-flag' />}
     <div styleName={cx('styles.content', { 'styles.desktop': isWide })}>
       <FlashMessage />
       {children}

--- a/src/holofuel/components/layout/PrimaryLayout/PrimaryLayout.js
+++ b/src/holofuel/components/layout/PrimaryLayout/PrimaryLayout.js
@@ -18,7 +18,7 @@ import Header from 'holofuel/components/Header'
 import FlashMessage from 'holofuel/components/FlashMessage'
 import AlphaFlag from 'holofuel/components/AlphaFlag'
 import { shouldShowTransactionInInbox } from 'models/Transaction'
-import { HOME_PATH } from 'holofuel/utils/urls'
+import { INBOX_PATH } from 'holofuel/utils/urls'
 import { wsConnection } from 'holochainClient'
 import styles from './PrimaryLayout.module.css' // eslint-disable-line no-unused-vars
 import 'holofuel/global-styles/colors.css'
@@ -60,7 +60,7 @@ function PrimaryLayout ({
       setShouldRefetchUser(true)
       let defaultPath
       if (process.env.REACT_APP_HOLOFUEL_APP === 'true') {
-        defaultPath = HOME_PATH
+        defaultPath = INBOX_PATH
       } else {
         defaultPath = '/admin/login'
       }

--- a/src/holofuel/components/layout/PrimaryLayout/PrimaryLayout.module.css
+++ b/src/holofuel/components/layout/PrimaryLayout/PrimaryLayout.module.css
@@ -7,6 +7,8 @@
 }
 
 .wide {
+  display: flex;
+  overflow: hidden;
   padding: 0;
 }
 
@@ -40,5 +42,6 @@
 }
 
 .desktop {
-  left: 280px
+  flex: 1;
+  margin-left: 280px
 }

--- a/src/holofuel/components/layout/PrimaryLayout/PrimaryLayout.module.css
+++ b/src/holofuel/components/layout/PrimaryLayout/PrimaryLayout.module.css
@@ -38,3 +38,7 @@
 .side-menu {
   padding-right: 10px;
 }
+
+.desktop {
+  left: 280px
+}

--- a/src/holofuel/pages/Home/Home.js
+++ b/src/holofuel/pages/Home/Home.js
@@ -48,7 +48,7 @@ export default function Home () {
 
   const isLoadingFirstPendingTransactions = useLoadingFirstTime(isConnected && loadingTransactions)
 
-  return <PrimaryLayout headerProps={{ title: 'Test Fuel Home' }}>
+  return <PrimaryLayout headerProps={{ title: 'Home' }}>
     <div styleName='container'>
       <div styleName='backdrop' />
       <div styleName='avatar'>

--- a/src/holofuel/utils/urls.js
+++ b/src/holofuel/utils/urls.js
@@ -1,4 +1,4 @@
-export const HOME_PATH = 'home'
+// export const HOME_PATH = 'home'
 export const INBOX_PATH = 'inbox'
 export const OFFER_REQUEST_PATH = 'offer-request'
 export const HISTORY_PATH = 'history'

--- a/src/pages/Dashboard/Dashboard.js
+++ b/src/pages/Dashboard/Dashboard.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect } from 'react' // , useState
 import { isEmpty } from 'lodash/fp'
 import { useQuery } from '@apollo/react-hooks'
 import { Link, useLocation } from 'react-router-dom'
@@ -27,17 +27,17 @@ export default function Dashboard ({ earnings = mockEarnings }) {
   const isBalanceZero = Number(balance) === 0
 
   const greeting = !isEmpty(settings.hostName) ? `Hi ${settings.hostName}!` : 'Hi!'
-  const [urlOrigin, setUrlOrigin] = useState()
-  let location = useLocation()
-  
+  // const [urlOrigin, setUrlOrigin] = useState()
+  const location = useLocation()
+
   useEffect(() => {
-    let origin = window.location.origin.trim()
-    const hasTrailingSlash =  origin.charAt(origin.length - 1) === '/'
+    const origin = window.location.origin.trim()
+    const hasTrailingSlash = origin.charAt(origin.length - 1) === '/'
     if (hasTrailingSlash) {
       origin.slice(0, origin.length - 1)
     }
-    setUrlOrigin(window.location.origin)
-  }, [location, setUrlOrigin])
+    // setUrlOrigin(window.location.origin)
+  }, [location]) // setUrlOrigin
 
   return <PrimaryLayout headerProps={{ title: 'HP Admin' }}>
     <div styleName='avatar'>

--- a/src/pages/Dashboard/Dashboard.js
+++ b/src/pages/Dashboard/Dashboard.js
@@ -38,7 +38,6 @@ export default function Dashboard ({ earnings = mockEarnings }) {
     }
     setUrlOrigin(window.location.origin)
   }, [location, setUrlOrigin])
-  
 
   return <PrimaryLayout headerProps={{ title: 'HP Admin' }}>
     {/* <div styleName='avatar'>
@@ -96,9 +95,9 @@ function Card ({ title, subtitle, linkTo, children }) {
 
 // a react-router link that can also take an external url
 function MixedLink ({ to, children, ...props }) {
-  const isExternal = /^https?:\/\//.test(to)
+  const isExternal = /^https?:\/\//.test(to) || /^http?:\/\//.test(to)
   if (isExternal) {
-    return <a href={to} {...props}>
+    return <a href={to} target='_blank' rel='noopener noreferrer' {...props}>
       {children}
     </a>
   } else {

--- a/src/pages/Dashboard/Dashboard.js
+++ b/src/pages/Dashboard/Dashboard.js
@@ -28,13 +28,13 @@ export default function Dashboard ({ earnings = mockEarnings }) {
 
   const greeting = !isEmpty(settings.hostName) ? `Hi ${settings.hostName}!` : 'Hi!'
 
-  return <PrimaryLayout headerProps={{ title: 'HP Admin hApps' }}>
-    <div styleName='avatar'>
+  return <PrimaryLayout headerProps={{ title: 'HP Admin' }}>
+    {/* <div styleName='avatar'>
       <CopyAgentId agent={{ id: settings.hostPubKey }} hpAdmin isMe>
         <HashIcon hash={settings.hostPubKey} size={42} />
       </CopyAgentId>
-    </div>
-    <h2 styleName='greeting'>{greeting}</h2>
+    </div> */}
+    <h1 styleName='greeting'>{greeting}</h1>
 
     {false && <Card title='Hosting' linkTo='/admin/browse-happs' subtitle='Manage your Holo applications'>
       <div styleName='hosting-content' data-testid='hosted-apps'>

--- a/src/pages/Dashboard/Dashboard.js
+++ b/src/pages/Dashboard/Dashboard.js
@@ -28,7 +28,7 @@ export default function Dashboard ({ earnings = mockEarnings }) {
 
   const greeting = !isEmpty(settings.hostName) ? `Hi ${settings.hostName}!` : 'Hi!'
 
-  return <PrimaryLayout headerProps={{ title: 'HP Admin' }}>
+  return <PrimaryLayout headerProps={{ title: 'HP Admin hApps' }}>
     <div styleName='avatar'>
       <CopyAgentId agent={{ id: settings.hostPubKey }} hpAdmin isMe>
         <HashIcon hash={settings.hostPubKey} size={42} />

--- a/src/pages/Dashboard/Dashboard.js
+++ b/src/pages/Dashboard/Dashboard.js
@@ -3,10 +3,10 @@ import { isEmpty } from 'lodash/fp'
 import { useQuery } from '@apollo/react-hooks'
 import { Link, useLocation } from 'react-router-dom'
 import PrimaryLayout from 'components/layout/PrimaryLayout'
-// import HashIcon from 'components/HashIcon'
+import HashIcon from 'components/HashIcon'
 import LaptopIcon from 'components/icons/LaptopIcon'
 import PlusInDiscIcon from 'components/icons/PlusInDiscIcon'
-// import CopyAgentId from 'components/CopyAgentId'
+import CopyAgentId from 'components/CopyAgentId'
 import HposSettingsQuery from 'graphql/HposSettingsQuery.gql'
 import HolofuelLedgerQuery from 'graphql/HolofuelLedgerQuery.gql'
 import { presentHolofuelAmount } from 'utils'
@@ -40,12 +40,12 @@ export default function Dashboard ({ earnings = mockEarnings }) {
   }, [location, setUrlOrigin])
 
   return <PrimaryLayout headerProps={{ title: 'HP Admin' }}>
-    {/* <div styleName='avatar'>
+    <div styleName='avatar'>
       <CopyAgentId agent={{ id: settings.hostPubKey }} hpAdmin isMe>
         <HashIcon hash={settings.hostPubKey} size={42} />
       </CopyAgentId>
-    </div> */}
-    <h1 styleName='greeting'>{greeting}</h1>
+    </div>
+    <h2 styleName='greeting'>{greeting}</h2>
 
     {false && <Card title='Hosting' linkTo='/admin/browse-happs' subtitle='Manage your Holo applications'>
       <div styleName='hosting-content' data-testid='hosted-apps'>

--- a/src/pages/Dashboard/Dashboard.js
+++ b/src/pages/Dashboard/Dashboard.js
@@ -69,7 +69,7 @@ export default function Dashboard ({ earnings = mockEarnings }) {
       </div>
     </Card>}
 
-    <Card title='Test Fuel' linkTo={urlOrigin + '/holofuel/'} subtitle='Send, and receive TestFuel'>
+    <Card title='Test Fuel' linkTo='/holofuel/' subtitle='Send, and receive TestFuel'>
       <div styleName={cx('balance', { 'empty-balance': isBalanceZero })}>
         <h4 styleName='balance-header'>
           Current Balance

--- a/src/pages/Dashboard/Dashboard.js
+++ b/src/pages/Dashboard/Dashboard.js
@@ -1,12 +1,12 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { isEmpty } from 'lodash/fp'
 import { useQuery } from '@apollo/react-hooks'
-import { Link } from 'react-router-dom'
+import { Link, useLocation } from 'react-router-dom'
 import PrimaryLayout from 'components/layout/PrimaryLayout'
-import HashIcon from 'components/HashIcon'
+// import HashIcon from 'components/HashIcon'
 import LaptopIcon from 'components/icons/LaptopIcon'
 import PlusInDiscIcon from 'components/icons/PlusInDiscIcon'
-import CopyAgentId from 'components/CopyAgentId'
+// import CopyAgentId from 'components/CopyAgentId'
 import HposSettingsQuery from 'graphql/HposSettingsQuery.gql'
 import HolofuelLedgerQuery from 'graphql/HolofuelLedgerQuery.gql'
 import { presentHolofuelAmount } from 'utils'
@@ -27,6 +27,18 @@ export default function Dashboard ({ earnings = mockEarnings }) {
   const isBalanceZero = Number(balance) === 0
 
   const greeting = !isEmpty(settings.hostName) ? `Hi ${settings.hostName}!` : 'Hi!'
+  const [urlOrigin, setUrlOrigin] = useState()
+  let location = useLocation()
+  
+  useEffect(() => {
+    let origin = window.location.origin.trim()
+    const hasTrailingSlash =  origin.charAt(origin.length - 1) === '/'
+    if (hasTrailingSlash) {
+      origin.slice(0, origin.length - 1)
+    }
+    setUrlOrigin(window.location.origin)
+  }, [location, setUrlOrigin])
+  
 
   return <PrimaryLayout headerProps={{ title: 'HP Admin' }}>
     {/* <div styleName='avatar'>
@@ -58,7 +70,7 @@ export default function Dashboard ({ earnings = mockEarnings }) {
       </div>
     </Card>}
 
-    <Card title='Test Fuel' linkTo='/holofuel/' subtitle='Send, and receive TestFuel'>
+    <Card title='Test Fuel' linkTo={urlOrigin + '/holofuel/'} subtitle='Send, and receive TestFuel'>
       <div styleName={cx('balance', { 'empty-balance': isBalanceZero })}>
         <h4 styleName='balance-header'>
           Current Balance

--- a/src/pages/Dashboard/Dashboard.module.css
+++ b/src/pages/Dashboard/Dashboard.module.css
@@ -7,7 +7,7 @@
 .greeting {
   text-align: center;
   color: var(--color-limed-spruce);
-  margin: 36px 0px;
+  margin-bottom: 36px;
 }
 
 .hosting-content {

--- a/src/pages/Dashboard/Dashboard.module.css
+++ b/src/pages/Dashboard/Dashboard.module.css
@@ -7,7 +7,7 @@
 .greeting {
   text-align: center;
   color: var(--color-limed-spruce);
-  margin-bottom: 36px;
+  margin: 36px 0px;
 }
 
 .hosting-content {

--- a/src/utils/urls.js
+++ b/src/utils/urls.js
@@ -1,0 +1,4 @@
+
+export const ROOT = '/'
+export const HP_ADMIN_LOGIN = '/admin/login'
+export const HP_ADMIN_DASHBOARD = '/admin/dashboard'

--- a/src/utils/urls.js
+++ b/src/utils/urls.js
@@ -2,3 +2,4 @@
 export const ROOT = '/'
 export const HP_ADMIN_LOGIN = '/admin/login'
 export const HP_ADMIN_DASHBOARD = '/admin/dashboard'
+export const HP_ADMIN_SETTINGS = '/admin/settings'


### PR DESCRIPTION
### Updates:
UI/UX Edits as follows :
 #### hp-admin:
 - replace avatar hash with a gear icon
 - have holofuel open up into different tab
 - when on settings page, add a back arrow icon to return to the dashboard page
 - remove the side navbar
 - create a banner for alpha notice and legal info/links

 #### holofuel:
 - implement a responsive layout with desktop design pattern
 - indicate current/active page in the side navbar
 - update title in the header
 - remove the balance from side nav
 - add back arrow in front of hp admin to increase visual/cognitive distinction between returning to hp admin happ and navigating between holofuel pages