### PR TITLE
D-01106- remove copyAgentId fn from hp-admin icon

### DIFF
--- a/src/pages/Settings/Settings.js
+++ b/src/pages/Settings/Settings.js
@@ -4,7 +4,6 @@ import { useQuery, useMutation } from '@apollo/react-hooks'
 import './Settings.module.css'
 import { sliceHash as presentHash, presentAgentId } from 'utils'
 import HashIcon from 'components/HashIcon'
-import CopyAgentId from 'components/CopyAgentId'
 import PrimaryLayout from 'components/layout/PrimaryLayout'
 import Button from 'components/UIButton'
 import ArrowRightIcon from 'components/icons/ArrowRightIcon'
@@ -77,9 +76,7 @@ export function Settings () {
 
   return <PrimaryLayout headerProps={{ title: 'HoloPort Settings', showBackButton: true }}>
     <div styleName='avatar'>
-      <CopyAgentId agent={{ id: settings.hostPubKey }} hpAdmin isMe>
-        <HashIcon hash={settings.hostPubKey} size={42} />
-      </CopyAgentId>
+      <HashIcon hash={settings.hostPubKey} size={42} />
     </div>
     <div styleName='title'>{title}</div>
 


### PR DESCRIPTION
### Updates : 
- removes copy to clipboard functionality from hp-admin identicon in settings (as requested in QA)