### PR TITLE
D 01126 clipboard v2

### DIFF
--- a/src/components/CopyAgentId/CopyAgentId.js
+++ b/src/components/CopyAgentId/CopyAgentId.js
@@ -6,26 +6,19 @@ import { presentAgentId } from 'utils'
 export default function CopyAgentId ({
   agent,
   isMe,
-  hpAdmin,
   className,
   children
 }) {
-  let happName, hash, nickname, messageText
+  let messageText
 
-  if (hpAdmin) {
-    ({ id: hash, nickname } = agent)
-    happName = 'HP Admin'
-  } else {
-    ({ agentAddress: hash, nickname } = agent)
-    happName = 'HoloFuel'
-  }
+  const { id: hash, nickname } = agent
 
   if (isMe) {
-    messageText = `Your ${happName} Agent ID has been copied!`
+    messageText = `Your HP Admin Agent ID has been copied!`
   } else if (nickname) {
-    messageText = `${nickname}'s ${happName} Agent ID has been copied!`
+    messageText = `${nickname}'s HP Admin Agent ID has been copied!`
   } else {
-    messageText = `Full Agent ID of ${presentAgentId(hash)} has been copied!`
+    messageText = `Full HP Admin Agent ID of ${presentAgentId(hash)} has been copied!`
   }
 
   return <CopyToClipboard copyContent={hash} messageText={messageText} className={className}>

--- a/src/components/SideMenu/SideMenu.js
+++ b/src/components/SideMenu/SideMenu.js
@@ -19,7 +19,7 @@ export function SideMenu ({
   return <aside styleName={cx('drawer', { 'drawer--open': isOpen })}>
     <div styleName='container'>
       <header styleName='header'>
-        <CopyAgentId agent={{ id: currentUser.hostPubKey }} hpAdmin isMe>
+        <CopyAgentId agent={{ id: currentUser.hostPubKey }} isMe>
           <HashAvatar avatarUrl={avatarUrl} seed={currentUser.hostPubKey} size={48} styleName='avatar' />
         </CopyAgentId>
         <h2 styleName='host-name'>


### PR DESCRIPTION
@JettTech This just removes the holofuel case in the hp-admin `CopyAgentId` component. I went through the app and as far as I can tell we weren't using that case anywhere.

(Note that it's pointing at your original branch, not at `develop`)